### PR TITLE
update #7, 副代表の登録機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,3 +62,6 @@ gem 'twitter-bootstrap-rails'
 
 # heroku監視
 gem 'newrelic_rpm'
+
+# for e-mail validate
+gem 'validates_email_format_of'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,6 +220,8 @@ GEM
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    validates_email_format_of (1.6.3)
+      i18n
     warden (1.2.3)
       rack (>= 1.0)
     web-console (2.1.2)
@@ -253,4 +255,8 @@ DEPENDENCIES
   turbolinks
   twitter-bootstrap-rails
   uglifier (>= 1.3.0)
+  validates_email_format_of
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.10.5

--- a/app/assets/javascripts/sub_reps.coffee
+++ b/app/assets/javascripts/sub_reps.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/sub_reps.scss
+++ b/app/assets/stylesheets/sub_reps.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the SubReps controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -1,4 +1,4 @@
-class EmployeesController < ApplicationController
+class EmployeesController < GroupBase
   before_action :set_employee, only: [:show, :edit, :update, :destroy]
   before_action :get_groups # カレントユーザの所有する団体を@groupsとする
   load_and_authorize_resource # for cancancan
@@ -75,6 +75,7 @@ class EmployeesController < ApplicationController
     end
 
     def get_groups
-      @groups = Group.where( user_id: current_user.id ).where( group_category_id: 1)
+      super  # set @groups by GroupBase.get_groups
+      @groups = @groups.where( group_category_id: 1)
     end
 end

--- a/app/controllers/food_products_controller.rb
+++ b/app/controllers/food_products_controller.rb
@@ -1,4 +1,4 @@
-class FoodProductsController < ApplicationController
+class FoodProductsController < GroupBase
   before_action :set_food_product, only: [:show, :edit, :update, :destroy]
   before_action :get_groups # 各アクションの実行前に実行
   load_and_authorize_resource # for cancancan
@@ -74,8 +74,9 @@ class FoodProductsController < ApplicationController
       params.require(:food_product).permit(:group_id, :name, :num, :is_cooking, :start)
     end
 
-    # ユーザが所有し，模擬店(食品販売)のカテゴリの団体を取得する
     def get_groups
-      @groups = Group.where( user_id: current_user.id ).where( group_category_id: 1)
+      # ユーザが所有し，模擬店(食品販売)のカテゴリの団体を取得する
+      super  # set @groups by GroupBase.get_groups
+      @groups = @groups.where( group_category_id: 1)
     end
 end

--- a/app/controllers/group_base.rb
+++ b/app/controllers/group_base.rb
@@ -1,0 +1,8 @@
+class GroupBase < ApplicationController
+
+  def get_groups
+    # 登録時の選択肢に使うグループを取得
+    # 自分の所有するグループ, 副代表登録済み,
+    @groups = Group.get_has_subreps(current_user.id)
+  end
+end

--- a/app/controllers/group_base.rb
+++ b/app/controllers/group_base.rb
@@ -1,8 +1,15 @@
 class GroupBase < ApplicationController
 
-  def get_groups
+  before_action :set_groups # カレントユーザの所有する団体を@groupsへ
+
+  def set_groups
     # 登録時の選択肢に使うグループを取得
     # 自分の所有するグループ, 副代表登録済み,
-    @groups = Group.get_has_subreps(current_user.id)
+    @groups = Group.where(user_id: current_user.id)
+    # ログインユーザの所有しているグループのうち，
+    # 副代表が登録されていない団体数を取得する
+    @num_nosubrep_groups = @groups.count -
+                           Group.get_has_subreps(current_user.id).count
   end
+
 end

--- a/app/controllers/group_base.rb
+++ b/app/controllers/group_base.rb
@@ -3,6 +3,8 @@ class GroupBase < ApplicationController
   before_action :set_groups # カレントユーザの所有する団体を@groupsへ
 
   def set_groups
+    # ログインしていなければ何もしない
+    return if current_user.nil?
     # 登録時の選択肢に使うグループを取得
     # 自分の所有するグループ, 副代表登録済み,
     @groups = Group.where(user_id: current_user.id)

--- a/app/controllers/place_orders_controller.rb
+++ b/app/controllers/place_orders_controller.rb
@@ -1,11 +1,11 @@
-class PlaceOrdersController < ApplicationController
+class PlaceOrdersController < GroupBase
   before_action :set_place_order, only: [:show, :edit, :update, :destroy]
+  before_action :get_groups # カレントユーザの所有する団体を@groupsとする
   load_and_authorize_resource # for cancancan
 
   # GET /place_orders
   # GET /place_orders.json
   def index
-    @groups = Group.where( user_id: current_user.id ) # 所有する団体
     @place_orders = [] # 初期化
     @groups.each { |group|
       @place_orders += PlaceOrder.where( group_id: group.id ).order('id')

--- a/app/controllers/power_orders_controller.rb
+++ b/app/controllers/power_orders_controller.rb
@@ -1,4 +1,4 @@
-class PowerOrdersController < ApplicationController
+class PowerOrdersController < GroupBase
   before_action :set_power_order, only: [:show, :edit, :update, :destroy]
   before_action :get_groups # カレントユーザの所有する団体を@groupsとする
   load_and_authorize_resource # for cancancan
@@ -80,7 +80,8 @@ class PowerOrdersController < ApplicationController
     end
 
     def get_groups
+      super  # set @groups by GroupBase.get_groups
       # 自分の所有するグループでステージ以外
-      @groups = Group.where( user_id: current_user.id ).where( group_category_id: [1,2,4,5] )
+      @groups = @groups.where( group_category_id: [1,2,4,5] )
     end
 end

--- a/app/controllers/rental_orders_controller.rb
+++ b/app/controllers/rental_orders_controller.rb
@@ -1,4 +1,4 @@
-class RentalOrdersController < ApplicationController
+class RentalOrdersController < GroupBase
   before_action :set_rental_order, only: [:show, :edit, :update, :destroy]
   before_action :get_groups # カレントユーザの所有する団体を@groupsとする
   load_and_authorize_resource # for cancancan
@@ -77,9 +77,5 @@ class RentalOrdersController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def rental_order_params
       params.require(:rental_order).permit(:group_id, :rental_item_id, :num)
-    end
-
-    def get_groups
-      @groups = Group.where( user_id: current_user.id )
     end
 end

--- a/app/controllers/stage_orders_controller.rb
+++ b/app/controllers/stage_orders_controller.rb
@@ -1,4 +1,4 @@
-class StageOrdersController < ApplicationController
+class StageOrdersController < GroupBase
   before_action :set_stage_order, only: [:show, :edit, :update, :destroy]
   before_action :get_groups # カレントユーザの所有する団体を@groupsとする
   load_and_authorize_resource # for cancancan
@@ -75,9 +75,5 @@ class StageOrdersController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def stage_order_params
       params.require(:stage_order).permit(:group_id, :is_sunny, :fes_date_id, :stage_first, :stage_second, :time, :own_equipment, :bgm, :camera_permittion, :loud_sound)
-    end
-
-    def get_groups
-      @groups = Group.where( user_id: current_user.id )
     end
 end

--- a/app/controllers/sub_reps_controller.rb
+++ b/app/controllers/sub_reps_controller.rb
@@ -1,6 +1,7 @@
 class SubRepsController < ApplicationController
   before_action :set_sub_rep, only: [:show, :edit, :update, :destroy]
   before_action :get_groups # カレントユーザの所有する団体を@groupsとする
+  load_and_authorize_resource # for cancancan
 
   # GET /sub_reps
   # GET /sub_reps.json

--- a/app/controllers/sub_reps_controller.rb
+++ b/app/controllers/sub_reps_controller.rb
@@ -1,4 +1,4 @@
-class SubRepsController < ApplicationController
+class SubRepsController < GroupBase
   before_action :set_sub_rep, only: [:show, :edit, :update, :destroy]
   before_action :get_groups # カレントユーザの所有する団体を@groupsとする
   load_and_authorize_resource # for cancancan

--- a/app/controllers/sub_reps_controller.rb
+++ b/app/controllers/sub_reps_controller.rb
@@ -1,0 +1,74 @@
+class SubRepsController < ApplicationController
+  before_action :set_sub_rep, only: [:show, :edit, :update, :destroy]
+
+  # GET /sub_reps
+  # GET /sub_reps.json
+  def index
+    @sub_reps = SubRep.all
+  end
+
+  # GET /sub_reps/1
+  # GET /sub_reps/1.json
+  def show
+  end
+
+  # GET /sub_reps/new
+  def new
+    @sub_rep = SubRep.new
+  end
+
+  # GET /sub_reps/1/edit
+  def edit
+  end
+
+  # POST /sub_reps
+  # POST /sub_reps.json
+  def create
+    @sub_rep = SubRep.new(sub_rep_params)
+
+    respond_to do |format|
+      if @sub_rep.save
+        format.html { redirect_to @sub_rep, notice: 'Sub rep was successfully created.' }
+        format.json { render :show, status: :created, location: @sub_rep }
+      else
+        format.html { render :new }
+        format.json { render json: @sub_rep.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /sub_reps/1
+  # PATCH/PUT /sub_reps/1.json
+  def update
+    respond_to do |format|
+      if @sub_rep.update(sub_rep_params)
+        format.html { redirect_to @sub_rep, notice: 'Sub rep was successfully updated.' }
+        format.json { render :show, status: :ok, location: @sub_rep }
+      else
+        format.html { render :edit }
+        format.json { render json: @sub_rep.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /sub_reps/1
+  # DELETE /sub_reps/1.json
+  def destroy
+    @sub_rep.destroy
+    respond_to do |format|
+      format.html { redirect_to sub_reps_url, notice: 'Sub rep was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_sub_rep
+      @sub_rep = SubRep.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def sub_rep_params
+      params.require(:sub_rep).permit(:group_id, :name_ja, :name_en, :department_id, :grade_id, :tel, :email)
+    end
+end

--- a/app/controllers/sub_reps_controller.rb
+++ b/app/controllers/sub_reps_controller.rb
@@ -1,5 +1,6 @@
 class SubRepsController < ApplicationController
   before_action :set_sub_rep, only: [:show, :edit, :update, :destroy]
+  before_action :get_groups # カレントユーザの所有する団体を@groupsとする
 
   # GET /sub_reps
   # GET /sub_reps.json
@@ -70,5 +71,9 @@ class SubRepsController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def sub_rep_params
       params.require(:sub_rep).permit(:group_id, :name_ja, :name_en, :department_id, :grade_id, :tel, :email)
+    end
+
+    def get_groups
+      @groups = Group.where( user_id: current_user.id )
     end
 end

--- a/app/controllers/sub_reps_controller.rb
+++ b/app/controllers/sub_reps_controller.rb
@@ -6,7 +6,7 @@ class SubRepsController < ApplicationController
   # GET /sub_reps
   # GET /sub_reps.json
   def index
-    @sub_reps = SubRep.all
+    @sub_reps = SubRep.where(group_id: @groups)
   end
 
   # GET /sub_reps/1

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,19 +1,18 @@
-class WelcomeController < ApplicationController
+class WelcomeController < GroupBase
+
   authorize_resource :class => false # for cancancan
 
   def index
-
     # UserDetail.find( id )だと存在しな時にエラー吐く. nilを渡すようにする
     @user_detail = UserDetail.find_by(user_id: current_user.id)
 
     if @user_detail.nil? # ユーザ情報登録前
       @name = current_user.email
-      render 'regist_user_detail' # viewをviews/welcome/regist_user_detailに,
+      render 'regist_user_detail' # viewをviews/welcome/regist_user_detailに
       # renderで指定したviewはindexメソッドの終了時に, デフォルトに代わって描写される.
     else
       @name = @user_detail.name_ja # そのうちlocaleで判断したい
     end
-
   end
 
   def regist_user_detail

--- a/app/helpers/sub_reps_helper.rb
+++ b/app/helpers/sub_reps_helper.rb
@@ -1,0 +1,2 @@
+module SubRepsHelper
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -49,14 +49,17 @@ class Ability
     end
     if user.role_id == 3 then # for user (デフォルトのrole)
       can :manage, :welcome
-      # emailのconfirmが終わっていれば
+      #
+      # TODO: emailのconfirmで判定する
+      # confirmした後のみ各種CURDできるようにさせたい．
       #
       # UserDetailの自分のレコードは作成, 更新, 読みが可能. 削除はだめ.
       can [:read, :create, :update], UserDetail, :user_id => user.id
       # 所有するGroupのレコードは自由に触れる
       can :manage, Group, :user_id => user.id
-      # 貸出物品は自分の団体のみ読み，更新を許可
+      # ユーザに紐付いている参加団体
       groups = Group.where( user_id: user.id ).pluck('id')
+      # 貸出物品は自分の団体のみ読み，更新を許可
       can [:read, :update], RentalOrder, :group_id => groups
       # 電力申請は自分の団体のみ作成，読み，更新，削除を許可
       can :manage, PowerOrder, :group_id => groups
@@ -76,6 +79,9 @@ class Ability
       can :manage, PurchaseList, :food_product_id => food_ids
       # 店舗リストは読み，新規作成を許可
       can [:read, :create], Shop
+      # 副代表は自分の団体のみ自由に触れる．だたしnewはidに無関係に許可
+      can :manage, SubRep, :group_id => groups
+      can :new, SubRep
     end
 
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -45,9 +45,14 @@ class Group < ActiveRecord::Base
     order.save
   end
 
-  # 副代表の有無
   def is_exist_subrep
+    # 副代表の有無
     num_subrep = self.sub_reps.count
     return num_subrep > 0 ? true : false
+  end
+
+  def self.get_has_subreps(user_id)
+    # 副代表が登録済みの団体を返す
+    return Group.joins(:sub_reps).where( user_id: user_id )
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -53,6 +53,6 @@ class Group < ActiveRecord::Base
 
   def self.get_has_subreps(user_id)
     # 副代表が登録済みの団体を返す
-    return Group.joins(:sub_reps).where( user_id: user_id )
+    return Group.joins(:sub_reps).where(user_id: user_id)
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,7 @@
 class Group < ActiveRecord::Base
   belongs_to :group_category
   belongs_to :user
+  has_many :sub_reps
 
   validates :name, presence: true, uniqueness: true
   validates :user, presence: true
@@ -42,5 +43,11 @@ class Group < ActiveRecord::Base
     return if group_category_id == 3 # ステージ企画ならば戻る
     order = PlaceOrder.new( group_id: id )
     order.save
+  end
+
+  # 副代表の有無
+  def is_exist_subrep
+    num_subrep = self.sub_reps.count
+    return num_subrep > 0 ? true : false
   end
 end

--- a/app/models/sub_rep.rb
+++ b/app/models/sub_rep.rb
@@ -2,4 +2,16 @@ class SubRep < ActiveRecord::Base
   belongs_to :group
   belongs_to :department
   belongs_to :grade
+
+  # 必須入力
+  validates :group_id, :name_ja, :name_en, :tel, :email, :department_id, :grade_id,
+    presence: true
+
+  # 半角英字と半角スペースのみ
+  validates :name_en, format: { with: /\A[a-zA-Z\s]+\z/i }
+
+  # tel -> 半角数字とハイフンのみ, ( [333-4444-4444, for 携帯], [4444-22-4444, for 固定] )
+  validates :tel, format: { with: /(\A\d{3}-\d{4}-\d{4}+\z)|(\A\d{4}-\d{2}-\d{4})+\z/i }
+
+  validates :email, :email_format => { :message => '有効なe-mailアドレスを入力してください' }
 end

--- a/app/models/sub_rep.rb
+++ b/app/models/sub_rep.rb
@@ -1,0 +1,5 @@
+class SubRep < ActiveRecord::Base
+  belongs_to :group
+  belongs_to :department
+  belongs_to :grade
+end

--- a/app/views/shared/_warning_subrep.html.erb
+++ b/app/views/shared/_warning_subrep.html.erb
@@ -1,0 +1,7 @@
+<%# 副代表が未登録ですよ! に書き換える %>
+<% if @num_nosubrep_groups > 0 %>
+  <div class="alert alert-dismissible alert-warning">
+    <h4>Warning!</h4>
+    <p>副代表の登録が未完了の団体があります．</p>
+  </div>
+<% end %>

--- a/app/views/sub_reps/_form.html.erb
+++ b/app/views/sub_reps/_form.html.erb
@@ -1,17 +1,20 @@
-<%= simple_form_for(@sub_rep) do |f| %>
-  <%= f.error_notification %>
+<%= simple_form_for @sub_rep, :html => { :class => 'form-horizontal' } do |f| %>
+  <%= f.input :group_id %>
+  <%= error_span(@sub_rep[:group_id]) %>
+  <%= f.input :name_ja %>
+  <%= error_span(@sub_rep[:name_ja]) %>
+  <%= f.input :name_en %>
+  <%= error_span(@sub_rep[:name_en]) %>
+  <%= f.input :department_id %>
+  <%= error_span(@sub_rep[:department_id]) %>
+  <%= f.input :grade_id %>
+  <%= error_span(@sub_rep[:grade_id]) %>
+  <%= f.input :tel %>
+  <%= error_span(@sub_rep[:tel]) %>
+  <%= f.input :email %>
+  <%= error_span(@sub_rep[:email]) %>
 
-  <div class="form-inputs">
-    <%= f.association :group %>
-    <%= f.input :name_ja %>
-    <%= f.input :name_en %>
-    <%= f.association :department %>
-    <%= f.association :grade %>
-    <%= f.input :tel %>
-    <%= f.input :email %>
-  </div>
-
-  <div class="form-actions">
-    <%= f.button :submit %>
-  </div>
+  <%= f.button :submit, :class => 'btn-primary' %>
+  <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
+                sub_reps_path, :class => 'btn btn-default' %>
 <% end %>

--- a/app/views/sub_reps/_form.html.erb
+++ b/app/views/sub_reps/_form.html.erb
@@ -1,0 +1,17 @@
+<%= simple_form_for(@sub_rep) do |f| %>
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
+    <%= f.association :group %>
+    <%= f.input :name_ja %>
+    <%= f.input :name_en %>
+    <%= f.association :department %>
+    <%= f.association :grade %>
+    <%= f.input :tel %>
+    <%= f.input :email %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit %>
+  </div>
+<% end %>

--- a/app/views/sub_reps/_form.html.erb
+++ b/app/views/sub_reps/_form.html.erb
@@ -1,16 +1,23 @@
-<%= simple_form_for @sub_rep, :html => { :class => 'form-horizontal' } do |f| %>
-  <%= f.input :group_id %>
+<%= simple_form_for @sub_rep, wrapper: "horizontal_form", :html => { :class => 'form-horizontal' } do |f| %>
+
+  <%= f.association :group, collection: @groups, selected: @sub_rep.group_id %>
   <%= error_span(@sub_rep[:group_id]) %>
+
   <%= f.input :name_ja %>
   <%= error_span(@sub_rep[:name_ja]) %>
+
   <%= f.input :name_en %>
   <%= error_span(@sub_rep[:name_en]) %>
-  <%= f.input :department_id %>
+
+  <%= f.association :department, label_method: :name_ja %>
   <%= error_span(@sub_rep[:department_id]) %>
-  <%= f.input :grade_id %>
+
+  <%= f.association :grade, label_method: :name %>
   <%= error_span(@sub_rep[:grade_id]) %>
+
   <%= f.input :tel %>
   <%= error_span(@sub_rep[:tel]) %>
+
   <%= f.input :email %>
   <%= error_span(@sub_rep[:email]) %>
 

--- a/app/views/sub_reps/edit.html.erb
+++ b/app/views/sub_reps/edit.html.erb
@@ -1,6 +1,5 @@
-<h1>Editing Sub Rep</h1>
-
-<%= render 'form' %>
-
-<%= link_to 'Show', @sub_rep %> |
-<%= link_to 'Back', sub_reps_path %>
+<%- model_class = SubRep -%>
+<div class="page-header">
+  <h1><%=t '.title', :default => [:'helpers.titles.edit', 'Edit %{model}'], :model => model_class.model_name.human.titleize %></h1>
+</div>
+<%= render :partial => 'form' %>

--- a/app/views/sub_reps/edit.html.erb
+++ b/app/views/sub_reps/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Sub Rep</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Show', @sub_rep %> |
+<%= link_to 'Back', sub_reps_path %>

--- a/app/views/sub_reps/index.html.erb
+++ b/app/views/sub_reps/index.html.erb
@@ -5,30 +5,26 @@
 <table class="table table-striped">
   <thead>
     <tr>
-      <th><%= model_class.human_attribute_name(:id) %></th>
-      <th><%= model_class.human_attribute_name(:group_id) %></th>
+      <th><%= model_class.human_attribute_name(:group_name) %></th>
       <th><%= model_class.human_attribute_name(:name_ja) %></th>
       <th><%= model_class.human_attribute_name(:name_en) %></th>
-      <th><%= model_class.human_attribute_name(:department_id) %></th>
-      <th><%= model_class.human_attribute_name(:grade_id) %></th>
+      <th><%= model_class.human_attribute_name(:department) %></th>
+      <th><%= model_class.human_attribute_name(:grade) %></th>
       <th><%= model_class.human_attribute_name(:tel) %></th>
       <th><%= model_class.human_attribute_name(:email) %></th>
-      <th><%= model_class.human_attribute_name(:created_at) %></th>
       <th><%=t '.actions', :default => t("helpers.actions") %></th>
     </tr>
   </thead>
   <tbody>
     <% @sub_reps.each do |sub_rep| %>
       <tr>
-        <td><%= link_to sub_rep.id, sub_rep_path(sub_rep) %></td>
-        <td><%= sub_rep.group_id %></td>
+        <td><%= sub_rep.group.name %></td>
         <td><%= sub_rep.name_ja %></td>
         <td><%= sub_rep.name_en %></td>
-        <td><%= sub_rep.department_id %></td>
-        <td><%= sub_rep.grade_id %></td>
+        <td><%= sub_rep.department.name_ja %></td>
+        <td><%= sub_rep.grade.name %></td>
         <td><%= sub_rep.tel %></td>
         <td><%= sub_rep.email %></td>
-        <td><%=l sub_rep.created_at %></td>
         <td>
           <%= link_to t('.edit', :default => t("helpers.links.edit")),
                       edit_sub_rep_path(sub_rep), :class => 'btn btn-default btn-xs' %>

--- a/app/views/sub_reps/index.html.erb
+++ b/app/views/sub_reps/index.html.erb
@@ -1,39 +1,48 @@
-<p id="notice"><%= notice %></p>
-
-<h1>Listing Sub Reps</h1>
-
-<table>
+<%- model_class = SubRep -%>
+<div class="page-header">
+  <h1><%=t '.title', :default => model_class.model_name.human.pluralize.titleize %></h1>
+</div>
+<table class="table table-striped">
   <thead>
     <tr>
-      <th>Group</th>
-      <th>Name ja</th>
-      <th>Name en</th>
-      <th>Department</th>
-      <th>Grade</th>
-      <th>Tel</th>
-      <th>Email</th>
-      <th colspan="3"></th>
+      <th><%= model_class.human_attribute_name(:id) %></th>
+      <th><%= model_class.human_attribute_name(:group_id) %></th>
+      <th><%= model_class.human_attribute_name(:name_ja) %></th>
+      <th><%= model_class.human_attribute_name(:name_en) %></th>
+      <th><%= model_class.human_attribute_name(:department_id) %></th>
+      <th><%= model_class.human_attribute_name(:grade_id) %></th>
+      <th><%= model_class.human_attribute_name(:tel) %></th>
+      <th><%= model_class.human_attribute_name(:email) %></th>
+      <th><%= model_class.human_attribute_name(:created_at) %></th>
+      <th><%=t '.actions', :default => t("helpers.actions") %></th>
     </tr>
   </thead>
-
   <tbody>
     <% @sub_reps.each do |sub_rep| %>
       <tr>
-        <td><%= sub_rep.group %></td>
+        <td><%= link_to sub_rep.id, sub_rep_path(sub_rep) %></td>
+        <td><%= sub_rep.group_id %></td>
         <td><%= sub_rep.name_ja %></td>
         <td><%= sub_rep.name_en %></td>
-        <td><%= sub_rep.department %></td>
-        <td><%= sub_rep.grade %></td>
+        <td><%= sub_rep.department_id %></td>
+        <td><%= sub_rep.grade_id %></td>
         <td><%= sub_rep.tel %></td>
         <td><%= sub_rep.email %></td>
-        <td><%= link_to 'Show', sub_rep %></td>
-        <td><%= link_to 'Edit', edit_sub_rep_path(sub_rep) %></td>
-        <td><%= link_to 'Destroy', sub_rep, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%=l sub_rep.created_at %></td>
+        <td>
+          <%= link_to t('.edit', :default => t("helpers.links.edit")),
+                      edit_sub_rep_path(sub_rep), :class => 'btn btn-default btn-xs' %>
+          <%= link_to t('.destroy', :default => t("helpers.links.destroy")),
+                      sub_rep_path(sub_rep),
+                      :method => :delete,
+                      :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
+                      :class => 'btn btn-xs btn-danger' %>
+        </td>
       </tr>
     <% end %>
   </tbody>
 </table>
 
-<br>
-
-<%= link_to 'New Sub rep', new_sub_rep_path %>
+<%= link_to t('.new', :default => t("helpers.links.new")),
+            new_sub_rep_path,
+            :class => 'btn btn-primary' %>

--- a/app/views/sub_reps/index.html.erb
+++ b/app/views/sub_reps/index.html.erb
@@ -2,6 +2,10 @@
 <div class="page-header">
   <h1><%=t '.title', :default => model_class.model_name.human.pluralize.titleize %></h1>
 </div>
+
+<%# 副代表未登録の警告 %>
+<%= render partial: 'shared/warning_subrep' %>
+
 <table class="table table-striped">
   <thead>
     <tr>

--- a/app/views/sub_reps/index.html.erb
+++ b/app/views/sub_reps/index.html.erb
@@ -1,0 +1,39 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Listing Sub Reps</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Group</th>
+      <th>Name ja</th>
+      <th>Name en</th>
+      <th>Department</th>
+      <th>Grade</th>
+      <th>Tel</th>
+      <th>Email</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @sub_reps.each do |sub_rep| %>
+      <tr>
+        <td><%= sub_rep.group %></td>
+        <td><%= sub_rep.name_ja %></td>
+        <td><%= sub_rep.name_en %></td>
+        <td><%= sub_rep.department %></td>
+        <td><%= sub_rep.grade %></td>
+        <td><%= sub_rep.tel %></td>
+        <td><%= sub_rep.email %></td>
+        <td><%= link_to 'Show', sub_rep %></td>
+        <td><%= link_to 'Edit', edit_sub_rep_path(sub_rep) %></td>
+        <td><%= link_to 'Destroy', sub_rep, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Sub rep', new_sub_rep_path %>

--- a/app/views/sub_reps/index.json.jbuilder
+++ b/app/views/sub_reps/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array!(@sub_reps) do |sub_rep|
+  json.extract! sub_rep, :id, :group_id, :name_ja, :name_en, :department_id, :grade_id, :tel, :email
+  json.url sub_rep_url(sub_rep, format: :json)
+end

--- a/app/views/sub_reps/new.html.erb
+++ b/app/views/sub_reps/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Sub Rep</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Back', sub_reps_path %>

--- a/app/views/sub_reps/new.html.erb
+++ b/app/views/sub_reps/new.html.erb
@@ -1,5 +1,5 @@
-<h1>New Sub Rep</h1>
-
-<%= render 'form' %>
-
-<%= link_to 'Back', sub_reps_path %>
+<%- model_class = SubRep -%>
+<div class="page-header">
+  <h1><%=t '.title', :default => [:'helpers.titles.new', 'New %{model}'], :model => model_class.model_name.human.titleize %></h1>
+</div>
+<%= render :partial => 'form' %>

--- a/app/views/sub_reps/show.html.erb
+++ b/app/views/sub_reps/show.html.erb
@@ -1,0 +1,39 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Group:</strong>
+  <%= @sub_rep.group %>
+</p>
+
+<p>
+  <strong>Name ja:</strong>
+  <%= @sub_rep.name_ja %>
+</p>
+
+<p>
+  <strong>Name en:</strong>
+  <%= @sub_rep.name_en %>
+</p>
+
+<p>
+  <strong>Department:</strong>
+  <%= @sub_rep.department %>
+</p>
+
+<p>
+  <strong>Grade:</strong>
+  <%= @sub_rep.grade %>
+</p>
+
+<p>
+  <strong>Tel:</strong>
+  <%= @sub_rep.tel %>
+</p>
+
+<p>
+  <strong>Email:</strong>
+  <%= @sub_rep.email %>
+</p>
+
+<%= link_to 'Edit', edit_sub_rep_path(@sub_rep) %> |
+<%= link_to 'Back', sub_reps_path %>

--- a/app/views/sub_reps/show.html.erb
+++ b/app/views/sub_reps/show.html.erb
@@ -1,39 +1,31 @@
-<p id="notice"><%= notice %></p>
+<%- model_class = SubRep -%>
+<div class="page-header">
+  <h1><%=t '.title', :default => model_class.model_name.human.titleize %></h1>
+</div>
 
-<p>
-  <strong>Group:</strong>
-  <%= @sub_rep.group %>
-</p>
+<dl class="dl-horizontal">
+  <dt><strong><%= model_class.human_attribute_name(:group_id) %>:</strong></dt>
+  <dd><%= @sub_rep.group_id %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:name_ja) %>:</strong></dt>
+  <dd><%= @sub_rep.name_ja %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:name_en) %>:</strong></dt>
+  <dd><%= @sub_rep.name_en %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:department_id) %>:</strong></dt>
+  <dd><%= @sub_rep.department_id %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:grade_id) %>:</strong></dt>
+  <dd><%= @sub_rep.grade_id %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:tel) %>:</strong></dt>
+  <dd><%= @sub_rep.tel %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:email) %>:</strong></dt>
+  <dd><%= @sub_rep.email %></dd>
+</dl>
 
-<p>
-  <strong>Name ja:</strong>
-  <%= @sub_rep.name_ja %>
-</p>
-
-<p>
-  <strong>Name en:</strong>
-  <%= @sub_rep.name_en %>
-</p>
-
-<p>
-  <strong>Department:</strong>
-  <%= @sub_rep.department %>
-</p>
-
-<p>
-  <strong>Grade:</strong>
-  <%= @sub_rep.grade %>
-</p>
-
-<p>
-  <strong>Tel:</strong>
-  <%= @sub_rep.tel %>
-</p>
-
-<p>
-  <strong>Email:</strong>
-  <%= @sub_rep.email %>
-</p>
-
-<%= link_to 'Edit', edit_sub_rep_path(@sub_rep) %> |
-<%= link_to 'Back', sub_reps_path %>
+<%= link_to t('.back', :default => t("helpers.links.back")),
+              sub_reps_path, :class => 'btn btn-default'  %>
+<%= link_to t('.edit', :default => t("helpers.links.edit")),
+              edit_sub_rep_path(@sub_rep), :class => 'btn btn-default' %>
+<%= link_to t('.destroy', :default => t("helpers.links.destroy")),
+              sub_rep_path(@sub_rep),
+              :method => 'delete',
+              :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
+              :class => 'btn btn-danger' %>

--- a/app/views/sub_reps/show.json.jbuilder
+++ b/app/views/sub_reps/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! @sub_rep, :id, :group_id, :name_ja, :name_en, :department_id, :grade_id, :tel, :email, :created_at, :updated_at

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,4 +1,6 @@
 <%= render 'dashboard' %>
+<%# 副代表未登録の警告 %>
+<%= render partial: 'shared/warning_subrep' %>
 
 <div class="panel panel-primary">
   <div class="panel-heading">
@@ -15,18 +17,23 @@
   </div>
 </div>
 
-<div class="panel panel-primary">
-  <div class="panel-heading">
-    <h3 class="panel-title">副代表</h3>
+<% if @num_nosubrep_groups > 0 %>
+  <%# 未登録の団体がある場合は副代表の枠をwarningへ変更 %>
+  <div class="panel panel-warning">
+<% else %>
+  <div class="panel panel-primary">
+<% end %>
+    <div class="panel-heading">
+      <h3 class="panel-title">副代表</h3>
+    </div>
+    <div class="panel-body">
+      参加団体の副代表を追加・編集します。各種申請には副代表の登録が必要です。<br>
+      対象: 全ての団体
+      <%= link_to t('welcome_controller.index'),
+              sub_reps_path,
+              :class => 'btn btn-default' %>
+    </div>
   </div>
-  <div class="panel-body">
-    参加団体の副代表を追加・編集します。<br>
-    対象: 全ての団体
-    <%= link_to t('welcome_controller.index'),
-            sub_reps_path,
-            :class => 'btn btn-default' %>
-  </div>
-</div>
 
 <div class="panel panel-primary">
   <div class="panel-heading">

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -17,6 +17,19 @@
 
 <div class="panel panel-primary">
   <div class="panel-heading">
+    <h3 class="panel-title">副代表</h3>
+  </div>
+  <div class="panel-body">
+    参加団体の副代表を追加・編集します。<br>
+    対象: 全ての団体
+    <%= link_to t('welcome_controller.index'),
+            sub_reps_path,
+            :class => 'btn btn-default' %>
+  </div>
+</div>
+
+<div class="panel panel-primary">
+  <div class="panel-heading">
     <h3 class="panel-title">物品貸出</h3>
   </div>
   <div class="panel-body">

--- a/config/locales/01_model/ja.yml
+++ b/config/locales/01_model/ja.yml
@@ -13,6 +13,7 @@ ja:
       food_product: 販売食品
       purchase_list: 購入リスト
       shop: 仕入先
+      sub_rep: 副代表
     attributes:
         group:
           name: 運営団体の名称
@@ -87,3 +88,10 @@ ja:
           is_closed_fri: 金曜定休
           is_closed_sat: 土曜定休
           is_closed_holiday: 祝日定休
+        sub_rep:
+          group_name: 運営団体の名称
+          name_ja: 氏名
+          name_en: Name
+          department: 所属
+          grade: 学年
+          tel: 電話番号

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :sub_reps
   resources :purchase_lists do
     # 標準の7つ以外を追加する
     collection do

--- a/db/migrate/20151225141723_create_sub_reps.rb
+++ b/db/migrate/20151225141723_create_sub_reps.rb
@@ -1,0 +1,15 @@
+class CreateSubReps < ActiveRecord::Migration
+  def change
+    create_table :sub_reps do |t|
+      t.references :group, index: true, foreign_key: true, null: false
+      t.string :name_ja, null: false
+      t.string :name_en, null: false
+      t.references :department, index: true, foreign_key: true, null: false
+      t.references :grade, index: true, foreign_key: true, null: false
+      t.string :tel, null: false
+      t.string :email, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150703190414) do
+ActiveRecord::Schema.define(version: 20151225141723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -227,6 +227,22 @@ ActiveRecord::Schema.define(version: 20150703190414) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "sub_reps", force: :cascade do |t|
+    t.integer  "group_id",      null: false
+    t.string   "name_ja",       null: false
+    t.string   "name_en",       null: false
+    t.integer  "department_id", null: false
+    t.integer  "grade_id",      null: false
+    t.string   "tel",           null: false
+    t.string   "email",         null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+  end
+
+  add_index "sub_reps", ["department_id"], name: "index_sub_reps_on_department_id", using: :btree
+  add_index "sub_reps", ["grade_id"], name: "index_sub_reps_on_grade_id", using: :btree
+  add_index "sub_reps", ["group_id"], name: "index_sub_reps_on_group_id", using: :btree
+
   create_table "user_details", force: :cascade do |t|
     t.integer  "user_id"
     t.string   "name_ja"
@@ -286,6 +302,9 @@ ActiveRecord::Schema.define(version: 20150703190414) do
   add_foreign_key "rental_orders", "rental_items"
   add_foreign_key "stage_orders", "fes_dates"
   add_foreign_key "stage_orders", "groups"
+  add_foreign_key "sub_reps", "departments"
+  add_foreign_key "sub_reps", "grades"
+  add_foreign_key "sub_reps", "groups"
   add_foreign_key "user_details", "departments"
   add_foreign_key "user_details", "grades"
   add_foreign_key "user_details", "users"

--- a/docs/log_subrepresetts.md
+++ b/docs/log_subrepresetts.md
@@ -121,3 +121,10 @@ Overwrite /Volumes/Data/Dropbox/nfes15/group_manager/app/views/sub_reps/index.ht
     - `group`
     - `department`
     - `grade`
+
+### _formの編集
+
+* 関連項目の変更 (`f.input` から`f.association`へ)
+    - group, `views/employee/_form...`を参考に
+        - コントローラで`@groups`を取得
+    - department, grade, `views/user_detail/_form`を参考に

--- a/docs/log_subrepresetts.md
+++ b/docs/log_subrepresetts.md
@@ -128,3 +128,11 @@ Overwrite /Volumes/Data/Dropbox/nfes15/group_manager/app/views/sub_reps/index.ht
     - group, `views/employee/_form...`を参考に
         - コントローラで`@groups`を取得
     - department, grade, `views/user_detail/_form`を参考に
+
+## 編集権限を付加
+
+* cancancan
+    - `models/ability.rb`で`SubRep`の権限を設定
+* コントローラ
+    - `controllers/sub_reps_controller.rb`に`load_and_authorize_resource`を追記
+        - これでcancancanの設定が反映される

--- a/docs/log_subrepresetts.md
+++ b/docs/log_subrepresetts.md
@@ -1,0 +1,47 @@
+<!-- ************** docs/log_subrepresetts.md **************
+Created    : 2015-Dec-25
+Last Change: 2015-Dec-25.
+-->
+
+
+副代表の追加
+
+## CURD
+
+```sh
+$ bundle exec rails g scaffold SubRep group:references name_ja:string name_en:string department:references grade:references tel:string email:string
+      invoke  active_record
+      create    db/migrate/20151225141723_create_sub_reps.rb
+      create    app/models/sub_rep.rb
+      invoke  resource_route
+       route    resources :sub_reps
+      invoke  scaffold_controller
+      create    app/controllers/sub_reps_controller.rb
+      invoke    erb
+      create      app/views/sub_reps
+      create      app/views/sub_reps/index.html.erb
+      create      app/views/sub_reps/edit.html.erb
+      create      app/views/sub_reps/show.html.erb
+      create      app/views/sub_reps/new.html.erb
+      create      app/views/sub_reps/_form.html.erb
+      invoke    helper
+      create      app/helpers/sub_reps_helper.rb
+      invoke    jbuilder
+      create      app/views/sub_reps/index.json.jbuilder
+      create      app/views/sub_reps/show.json.jbuilder
+      invoke  assets
+      invoke    coffee
+      create      app/assets/javascripts/sub_reps.coffee
+      invoke    scss
+      create      app/assets/stylesheets/sub_reps.scss
+      invoke  scss
+   identical    app/assets/stylesheets/scaffolds.scss
+
+$ vim db/migrate/20151225141723_create_sub_reps.rb
+# null 制約を追加
+$ rake db:migrate
+== 20151225141723 CreateSubReps: migrating ====================================
+-- create_table(:sub_reps)
+   -> 0.0626s
+== 20151225141723 CreateSubReps: migrated (0.0627s) ===========================
+```

--- a/docs/log_subrepresetts.md
+++ b/docs/log_subrepresetts.md
@@ -1,6 +1,6 @@
 <!-- ************** docs/log_subrepresetts.md **************
 Created    : 2015-Dec-25
-Last Change: 2015-Dec-25.
+Last Change: 2015-Dec-26.
 -->
 
 
@@ -44,4 +44,28 @@ $ rake db:migrate
 -- create_table(:sub_reps)
    -> 0.0626s
 == 20151225141723 CreateSubReps: migrated (0.0627s) ===========================
+```
+
+ここまで`8931b96`
+
+
+## バリデート追加
+
+```diff
+@@ -2,4 +2,16 @@ class SubRep < ActiveRecord::Base
+   belongs_to :group
+   belongs_to :department
+   belongs_to :grade
++
++  # 必須入力
++  validates :group_id, :name_ja, :name_en, :tel, :email, :department_id, :grade_id,
++    presence: true
++
++  # 半角英字と半角スペースのみ
++  validates :name_en, format: { with: /\A[a-zA-Z\s]+\z/i }
++
++  # tel -> 半角数字とハイフンのみ, ( [333-4444-4444, for 携帯], [4444-22-4444, for 固定] )
++  validates :tel, format: { with: /(\A\d{3}-\d{4}-\d{4}+\z)|(\A\d{4}-\d{2}-\d{4})+\z/i }
++
++  validates :email, :email_format => { :message => '有効なe-mailアドレスを入力してください' }
 ```

--- a/docs/log_subrepresetts.md
+++ b/docs/log_subrepresetts.md
@@ -69,3 +69,29 @@ $ rake db:migrate
 +
 +  validates :email, :email_format => { :message => '有効なe-mailアドレスを入力してください' }
 ```
+
+## 副代表の入力画面をDashboardに追加
+
+```diff
+--- a/app/views/welcome/index.html.erb
++++ b/app/views/welcome/index.html.erb
+@@ -17,6 +17,19 @@
+
++<div class="panel panel-primary">
++  <div class="panel-heading">
++    <h3 class="panel-title">副代表</h3>
++  </div>
++  <div class="panel-body">
++    参加団体の副代表を追加・編集します。<br>
++    対象: 全ての団体
++    <%= link_to t('welcome_controller.index'),
++            sub_reps_path,
++            :class => 'btn btn-default' %>
++  </div>
++</div>
++
+ <div class="panel panel-primary">
+   <div class="panel-heading">
+     <h3 class="panel-title">物品貸出</h3>
+   </div>
+```

--- a/docs/log_subrepresetts.md
+++ b/docs/log_subrepresetts.md
@@ -145,3 +145,10 @@ Overwrite /Volumes/Data/Dropbox/nfes15/group_manager/app/views/sub_reps/index.ht
 ## 各種申請時に選択可能な参加団体を変更
 
 副代表が登録されている団体のみを選択肢として与える．
+
+## 副代表登録の警告文を追加
+
+副代表が登録されていない団体がある場合にwarningを表示させる
+
+`app/views/shared/_warning_subrep.html.erb`を作成
+このパーシャルを`welcome/index`, `sub_reps/index.html.erb`で表示

--- a/docs/log_subrepresetts.md
+++ b/docs/log_subrepresetts.md
@@ -112,3 +112,12 @@ Overwrite /Volumes/Data/Dropbox/nfes15/group_manager/app/views/sub_reps/index.ht
     conflict  app/views/sub_reps/show.html.erb
        force  app/views/sub_reps/show.html.erb
 ```
+
+### index表示項目を整理
+
+* 不要な項目の削除
+    - id
+* 表示内容の変更
+    - `group`
+    - `department`
+    - `grade`

--- a/docs/log_subrepresetts.md
+++ b/docs/log_subrepresetts.md
@@ -136,3 +136,8 @@ Overwrite /Volumes/Data/Dropbox/nfes15/group_manager/app/views/sub_reps/index.ht
 * コントローラ
     - `controllers/sub_reps_controller.rb`に`load_and_authorize_resource`を追記
         - これでcancancanの設定が反映される
+
+## 各種申請時に副代表の登録を必須にする
+
+`cancancan`で編集可能なレコードを変更．
+ユーザが所有していて，副代表が登録済みのgroup_idのみに権限を与える

--- a/docs/log_subrepresetts.md
+++ b/docs/log_subrepresetts.md
@@ -95,3 +95,20 @@ $ rake db:migrate
      <h3 class="panel-title">物品貸出</h3>
    </div>
 ```
+
+## bootstrap適用
+
+```sh
+$ bundle exec rails g bootstrap:themed SubReps
+    conflict  app/views/sub_reps/index.html.erb
+Overwrite /Volumes/Data/Dropbox/nfes15/group_manager/app/views/sub_reps/index.html.erb? (enter "h" for help) [Ynaqdh] a
+       force  app/views/sub_reps/index.html.erb
+    conflict  app/views/sub_reps/new.html.erb
+       force  app/views/sub_reps/new.html.erb
+    conflict  app/views/sub_reps/edit.html.erb
+       force  app/views/sub_reps/edit.html.erb
+    conflict  app/views/sub_reps/_form.html.erb
+       force  app/views/sub_reps/_form.html.erb
+    conflict  app/views/sub_reps/show.html.erb
+       force  app/views/sub_reps/show.html.erb
+```

--- a/docs/log_subrepresetts.md
+++ b/docs/log_subrepresetts.md
@@ -1,6 +1,6 @@
 <!-- ************** docs/log_subrepresetts.md **************
 Created    : 2015-Dec-25
-Last Change: 2015-Dec-26.
+Last Change: 2015-Dec-27.
 -->
 
 
@@ -141,3 +141,7 @@ Overwrite /Volumes/Data/Dropbox/nfes15/group_manager/app/views/sub_reps/index.ht
 
 `cancancan`で編集可能なレコードを変更．
 ユーザが所有していて，副代表が登録済みのgroup_idのみに権限を与える
+
+## 各種申請時に選択可能な参加団体を変更
+
+副代表が登録されている団体のみを選択肢として与える．


### PR DESCRIPTION
### 追加機能

* 副代表の追加・編集・削除ページを追加
* `views/welcome/index`に副代表編集ページのリンクを追加
* cancancanで副代表が未登録の団体に対する操作を禁止
* 各種申請時の団体選択肢を副代表登録済みの団体のみに絞込