### PR TITLE
fix: controllers/group_base, 副代表未登録の警告表示条件で年度に対応

### DIFF
--- a/app/controllers/group_base.rb
+++ b/app/controllers/group_base.rb
@@ -13,7 +13,8 @@ class GroupBase < ApplicationController
     # ログインユーザの所有しているグループのうち，
     # 副代表が登録されていない団体数を取得する
     @num_nosubrep_groups = @groups.count -
-                           Group.get_has_subreps(current_user.id).count
+                           Group.where(fes_year: this_year).
+                                 get_has_subreps(current_user.id).count
   end
 
 end

--- a/app/views/shared/_warning_subrep.html.erb
+++ b/app/views/shared/_warning_subrep.html.erb
@@ -1,4 +1,4 @@
-<%# 副代表が未登録ですよ! に書き換える %>
+<%# 副代表が未登録ですよ! の警告を表示する %>
 <% if @num_nosubrep_groups > 0 %>
   <div class="alert alert-dismissible alert-warning">
     <h4>Warning!</h4>


### PR DESCRIPTION
副代表未登録の団体取得時に年度の絞込を追加