### PR TITLE
Managerが使用電力の申請を編集できるように

### DIFF
--- a/app/admin/power_order.rb
+++ b/app/admin/power_order.rb
@@ -11,6 +11,7 @@ ActiveAdmin.register PowerOrder do
     column :manufacturer
     column :model
     column :updated_at
+    actions
   end
 
   csv do


### PR DESCRIPTION
権限自体は元からあったので，`app/admin/power_order.rb`にactionsを追加して，閲覧,編集,削除へのリンクを表示させるようにしました

issue #72