### PR TITLE
年度が異なる同名の参加団体を登録可能に

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,7 +4,7 @@ class Group < ActiveRecord::Base
   belongs_to :fes_year
   has_many :sub_reps
 
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: { scope: :fes_year }
   validates :user, presence: true
   validates :activity, presence: true
   validates :group_category, presence: true


### PR DESCRIPTION
issue #96 

年度が異なる同名の参加団体を登録可能に修正

バグ: 
年度が異なる同名の参加団体が登録できなかった. 

変更点: 
以前 : nameでuniq制約
今回 : name && fes_yearでuniq制約