### PR TITLE
一般ユーザの「仕入先の新規作成」機能を削除

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -87,8 +87,8 @@ class Ability
       # 購入リストは自分が持つ販売食品に紐付いたもののみ自由に触れる
       food_ids = FoodProduct.where( group_id: groups ).pluck('id')
       can :manage, PurchaseList, :food_product_id => food_ids
-      # 店舗リストは読み，新規作成を許可
-      can [:read, :create], Shop
+      # 店舗リストは読みを許可
+      can [:read], Shop
       # 副代表は自分の団体のみ自由に触れる．
       # だたしnewはidに無関係に許可
       can :manage, SubRep, :group_id => groups

--- a/app/views/purchase_lists/new_cooking.html.erb
+++ b/app/views/purchase_lists/new_cooking.html.erb
@@ -10,4 +10,3 @@
 <%= render :partial => 'form_cooking' %>
 </br>
 </br>
-<%= render :partial => 'link_shop_new' %>

--- a/app/views/purchase_lists/new_noncooking.html.erb
+++ b/app/views/purchase_lists/new_noncooking.html.erb
@@ -10,4 +10,3 @@
 <%= render :partial => 'form_noncooking' %>
 </br>
 </br>
-<%= render :partial => 'link_shop_new' %>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -25,7 +25,3 @@
     <% end %>
   </tbody>
 </table>
-
-<%= link_to t('.new', :default => t("helpers.links.new")),
-            new_shop_path,
-            :class => 'btn btn-primary' %>


### PR DESCRIPTION
- viewファイルから「仕入先の新規作成」のリンクを消去
- 一般ユーザのshopモデルのcreate権限をcannotに変更

issue #76