### PR TITLE
fix Issue38, ユーザロールの権限とviewをConfigテーブルから制御

### DIFF
--- a/app/admin/config_user_permission.rb
+++ b/app/admin/config_user_permission.rb
@@ -1,0 +1,19 @@
+ActiveAdmin.register ConfigUserPermission do
+
+
+  # See permitted parameters documentation:
+  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  #
+  # permit_params :list, :of, :attributes, :on, :model
+  #
+  # or
+  #
+  # permit_params do
+  #   permitted = [:permitted, :attributes]
+  #   permitted << :other if resource.something?
+  #   permitted
+  # end
+
+  permit_params :form_name, :is_accepting, :is_only_show
+
+end

--- a/app/controllers/group_base.rb
+++ b/app/controllers/group_base.rb
@@ -1,6 +1,7 @@
 class GroupBase < ApplicationController
 
   before_action :set_groups # カレントユーザの所有する団体を@groupsへ
+  before_action :set_ability # カレントユーザの権限設定を@abilityへ
 
   def set_groups
     # ログインしていなければ何もしない
@@ -15,6 +16,11 @@ class GroupBase < ApplicationController
     @num_nosubrep_groups = @groups.count -
                            Group.where(fes_year: this_year).
                                  get_has_subreps(current_user.id).count
+  end
+
+  def set_ability
+    return if current_user.nil?
+    @ability = Ability.new(current_user)
   end
 
 end

--- a/app/controllers/purchase_lists_controller.rb
+++ b/app/controllers/purchase_lists_controller.rb
@@ -1,7 +1,7 @@
 class PurchaseListsController < GroupBase
   before_action :set_purchase_list, only: [:show, :edit, :update, :destroy]
   before_action :set_group_ids        # 各アクション実行前に実行
-  load_and_authorize_resource # for cancancan
+  load_and_authorize_resource :except=> [:index_cooking,:index_noncooking] # for cancancan
 
   # GET /purchase_lists
   # GET /purchase_lists.json

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,22 @@
 module ApplicationHelper
+
+  def show_edit_botton(path, record)
+    # editが許可された場合のみEditボタンを表示する
+    if @ability.can?(:update, record)
+      return link_to t('.edit', :default => t("helpers.links.edit")),
+        path,
+        :class => 'btn btn-default btn-xs'
+    end
+  end
+
+  def show_destroy_botton(path, record)
+    # destroyが許可された場合のみEditボタンを表示する
+    if @ability.can?(:destroy, record)
+      return link_to t('.destroy', :default => t("helpers.links.destroy")),
+        path,
+        :method => :delete,
+        :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
+        :class => 'btn btn-xs btn-danger'
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,4 +19,13 @@ module ApplicationHelper
         :class => 'btn btn-xs btn-danger'
     end
   end
+
+  def show_new_with_group(model, path)
+    # createが許可された場合のみNewボタンを表示する
+    if @ability.can?(:create, model.new(group_id: @groups.first.id))
+      return link_to t('.new', :default => t("helpers.links.new")),
+        path,
+        :class => 'btn btn-primary'
+    end
+  end
 end

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -1,2 +1,12 @@
 module GroupsHelper
+
+  def show_new_group()
+    # createが許可された場合のみNewボタンを表示する
+    if @ability.can?(:create, Group.new(user_id: current_user.id))
+      return link_to t('.new', :default => t("helpers.links.new")),
+        new_group_path,
+        :class => 'btn btn-primary'
+    end
+  end
+
 end

--- a/app/helpers/purchase_lists_helper.rb
+++ b/app/helpers/purchase_lists_helper.rb
@@ -1,2 +1,36 @@
 module PurchaseListsHelper
+
+  def show_new_noncooking(fesdate)
+    # 保存食品はいつでも買える
+    food_product = FoodProduct.find_by(group_id: @groups.first.id)
+    # createが許可された場合のみNewボタンを表示する
+    if @ability.can?(:create, PurchaseList.new(food_product_id: food_product.id))
+      return link_to "#{fesdate.date}" + 'に購入する提供品を追加',
+        new_noncooking_purchase_lists_path(fes_date_id: fesdate.id),  # 提供品
+        :class => 'btn btn-primary'
+    end
+  end
+
+  def show_new_nonfresh(fesdate)
+    # 保存食品はいつでも買える
+    food_product = FoodProduct.find_by(group_id: @groups.first.id)
+    # createが許可された場合のみNewボタンを表示する
+    if @ability.can?(:create, PurchaseList.new(food_product_id: food_product.id))
+      return link_to "#{fesdate.date}" + 'に購入する保存食品を追加',
+        new_cooking_purchase_lists_path(is_fresh: false, fes_date_id: fesdate.id), # 保存食品
+        :class => 'btn btn-primary'
+    end
+  end
+
+  def show_new_fresh(fesdate)
+    return if fesdate.days_num == 0  # 準備日に生鮮食品は買えない
+
+    food_product = FoodProduct.find_by(group_id: @groups.first.id)
+    # createが許可された場合のみNewボタンを表示する
+    if @ability.can?(:create, PurchaseList.new(food_product_id: food_product.id))
+      return link_to "#{fesdate.date}" + 'に使用する生鮮食品を追加',
+        new_cooking_purchase_lists_path(is_fresh: true, fes_date_id: fesdate.id), # 生鮮食品
+        :class => 'btn btn-primary'
+    end
+  end
 end

--- a/app/models/config_user_permission.rb
+++ b/app/models/config_user_permission.rb
@@ -1,0 +1,2 @@
+class ConfigUserPermission < ActiveRecord::Base
+end

--- a/app/models/config_user_permission.rb
+++ b/app/models/config_user_permission.rb
@@ -1,2 +1,15 @@
 class ConfigUserPermission < ActiveRecord::Base
+  validate :valid_boolean_unique
+
+  validates_presence_of :form_name
+  validates_uniqueness_of :form_name
+
+  def valid_boolean_unique
+    return unless [is_accepting, is_only_show].all?  # 全部0なら許可
+    unless [is_accepting, is_only_show].one? # trueは1個のみ
+      errors.add(:is_accepting, "全てチェックしないか，1個のみチェックしてください")
+      errors.add(:is_only_show, "全てチェックしないか，1個のみチェックしてください")
+    end
+  end
+
 end

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -20,19 +20,14 @@
         <td><%= employee.student_id %></td>
         <td><%= employee.employee_category %></td>
         <td>
-          <%= link_to t('.edit', :default => t("helpers.links.edit")),
-                      edit_employee_path(employee), :class => 'btn btn-default btn-xs' %>
-          <%= link_to t('.destroy', :default => t("helpers.links.destroy")),
-                      employee_path(employee),
-                      :method => :delete,
-                      :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
-                      :class => 'btn btn-xs btn-danger' %>
+          <%= show_edit_botton(edit_employee_path(employee), employee) %>
+          <%= show_destroy_botton(employee_path(employee), employee) %>
         </td>
       </tr>
     <% end %>
   </tbody>
 </table>
 
-<%= link_to t('.new', :default => t("helpers.links.new")),
-            new_employee_path,
-            :class => 'btn btn-primary' %>
+<%= link_to t('.back', :default => t("helpers.links.back")),
+              welcome_index_path, :class => 'btn btn-default'  %>
+<%= show_new_with_group(Employee, new_employee_path) %>

--- a/app/views/food_products/index.html.erb
+++ b/app/views/food_products/index.html.erb
@@ -22,19 +22,14 @@
         <td><%= food_product.disp_cooking %></td>
         <td><%= food_product.start %></td>
         <td>
-          <%= link_to t('.edit', :default => t("helpers.links.edit")),
-                      edit_food_product_path(food_product), :class => 'btn btn-default btn-xs' %>
-          <%= link_to t('.destroy', :default => t("helpers.links.destroy")),
-                      food_product_path(food_product),
-                      :method => :delete,
-                      :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
-                      :class => 'btn btn-xs btn-danger' %>
+          <%= show_edit_botton(edit_food_product_path(food_product), food_product) %>
+          <%= show_destroy_botton(food_product_path(food_product), food_product) %>
         </td>
       </tr>
     <% end %>
   </tbody>
 </table>
 
-<%= link_to t('.new', :default => t("helpers.links.new")),
-            new_food_product_path,
-            :class => 'btn btn-primary' %>
+<%= link_to t('.back', :default => t("helpers.links.back")),
+              welcome_index_path, :class => 'btn btn-default'  %>
+<%= show_new_with_group(FoodProduct, new_food_product_path) %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -22,13 +22,8 @@
         <td>
           <%= link_to t('.detail', :default => t("helpers.links.show")),
                       group_path(group), :class => 'btn btn-default btn-xs' %>
-          <%= link_to t('.edit', :default => t("helpers.links.edit")),
-                      edit_group_path(group), :class => 'btn btn-default btn-xs' %>
-          <%= link_to t('.destroy', :default => t("helpers.links.destroy")),
-                      group_path(group),
-                      :method => :delete,
-                      :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
-                      :class => 'btn btn-xs btn-danger' %>
+          <%= show_edit_botton(edit_group_path(group), group) %>
+          <%= show_destroy_botton(group_path(group), group) %>
         </td>
       </tr>
     <% end %>
@@ -37,6 +32,4 @@
 
 <%= link_to t('.back', :default => t("helpers.links.back")),
               welcome_index_path, :class => 'btn btn-default'  %>
-<%= link_to t('.new', :default => t("helpers.links.new")),
-            new_group_path,
-            :class => 'btn btn-primary' %>
+<%= show_new_group() %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -16,10 +16,5 @@
 
 <%= link_to t('.back', :default => t("helpers.links.back")),
               groups_path, :class => 'btn btn-default'  %>
-<%= link_to t('.edit', :default => t("helpers.links.edit")),
-              edit_group_path(@group), :class => 'btn btn-default' %>
-<%= link_to t('.destroy', :default => t("helpers.links.destroy")),
-              group_path(@group),
-              :method => 'delete',
-              :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
-              :class => 'btn btn-danger' %>
+<%= show_edit_botton(edit_group_path(@group), @group) %>
+<%= show_destroy_botton(group_path(@group), @group) %>

--- a/app/views/place_orders/index.html.erb
+++ b/app/views/place_orders/index.html.erb
@@ -20,8 +20,7 @@
         <td><%= place_order.second ? Place.find(place_order.second) : "未回答" %></td>
         <td><%= place_order.third  ? Place.find(place_order.third)  : "未回答" %></td>
         <td>
-          <%= link_to t('.edit', :default => t("helpers.links.edit")),
-                      edit_place_order_path(place_order), :class => 'btn btn-default btn-xs' %>
+          <%= show_edit_botton(edit_place_order_path(place_order), place_order) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/power_orders/index.html.erb
+++ b/app/views/power_orders/index.html.erb
@@ -22,19 +22,14 @@
         <td><%= power_order.manufacturer %></td>
         <td><%= power_order.model %></td>
         <td>
-          <%= link_to t('.edit', :default => t("helpers.links.edit")),
-                      edit_power_order_path(power_order), :class => 'btn btn-default btn-xs' %>
-          <%= link_to t('.destroy', :default => t("helpers.links.destroy")),
-                      power_order_path(power_order),
-                      :method => :delete,
-                      :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
-                      :class => 'btn btn-xs btn-danger' %>
+          <%= show_edit_botton(edit_power_order_path(power_order), power_order) %>
+          <%= show_destroy_botton(power_order_path(power_order), power_order) %>
         </td>
       </tr>
     <% end %>
   </tbody>
 </table>
 
-<%= link_to t('.new', :default => t("helpers.links.new")),
-            new_power_order_path,
-            :class => 'btn btn-primary' %>
+<%= link_to t('.back', :default => t("helpers.links.back")),
+              welcome_index_path, :class => 'btn btn-default'  %>
+<%= show_new_with_group(PowerOrder, new_power_order_path) %>

--- a/app/views/purchase_lists/index_cooking.html.erb
+++ b/app/views/purchase_lists/index_cooking.html.erb
@@ -23,13 +23,8 @@
         <td><%= purchase_list.shop.name %></td>
         <td><%= purchase_list.items %></td>
         <td>
-          <%= link_to t('.edit', :default => t("helpers.links.edit")),
-                      edit_purchase_list_path(purchase_list), :class => 'btn btn-default btn-xs' %>
-          <%= link_to t('.destroy', :default => t("helpers.links.destroy")),
-                      purchase_list_path(purchase_list),
-                      :method => :delete,
-                      :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
-                      :class => 'btn btn-xs btn-danger' %>
+          <%= show_edit_botton(edit_purchase_list_path(purchase_list), purchase_list) %>
+          <%= show_destroy_botton(purchase_list_path(purchase_list), purchase_list) %>
         </td>
       </tr>
     <% end %>
@@ -39,21 +34,15 @@
 <% fes_dates = FesDate.all %>
 
 <p>
-<% fes_dates[1, 2].each do |fesdate| %>
-  <%# 生鮮品は当日しか買えない %>
-  <%= link_to "#{fesdate.date}" + 'に使用する生鮮食品を追加',
-              new_cooking_purchase_lists_path(is_fresh: true, fes_date_id: fesdate.id), # 生鮮食品1日目
-              :class => 'btn btn-primary'%>
+<% fes_dates.each do |fesdate| %>
+  <%= show_new_fresh(fesdate) %>
 <% end %>
 <%= render :partial => 'warnign_fresh' %>
 </p>
 
 <p>
 <% fes_dates.each do |fesdate| %>
-  <%# 保存食品はいつでも買える %>
-  <%= link_to "#{fesdate.date}" + 'に購入する保存食品を追加',
-              new_cooking_purchase_lists_path(is_fresh: false, fes_date_id: fesdate.id),
-              :class => 'btn btn-primary'%>
+  <%= show_new_nonfresh(fesdate) %>
 <% end %>
 <%= render :partial => 'warnign_preserved' %>
 </p>

--- a/app/views/purchase_lists/index_noncooking.html.erb
+++ b/app/views/purchase_lists/index_noncooking.html.erb
@@ -21,13 +21,8 @@
         <td><%= purchase_list.shop.name %></td>
         <td><%= purchase_list.items %></td>
         <td>
-          <%= link_to t('.edit', :default => t("helpers.links.edit")),
-                      edit_purchase_list_path(purchase_list), :class => 'btn btn-default btn-xs' %>
-          <%= link_to t('.destroy', :default => t("helpers.links.destroy")),
-                      purchase_list_path(purchase_list),
-                      :method => :delete,
-                      :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
-                      :class => 'btn btn-xs btn-danger' %>
+          <%= show_edit_botton(edit_purchase_list_path(purchase_list), purchase_list) %>
+          <%= show_destroy_botton(purchase_list_path(purchase_list), purchase_list) %>
         </td>
       </tr>
     <% end %>
@@ -38,9 +33,6 @@
 
 <p>
 <% fes_dates.each do |fesdate| %>
-  <%# 提供品はいつでも買える %>
-  <%= link_to "#{fesdate.date}" + 'に購入する提供品を追加',
-              new_noncooking_purchase_lists_path(fes_date_id: fesdate.id),
-              :class => 'btn btn-primary'%>
+  <%= show_new_noncooking(fesdate) %>
 <% end %>
 </p>

--- a/app/views/rental_orders/index.html.erb
+++ b/app/views/rental_orders/index.html.erb
@@ -19,8 +19,7 @@
             <td><%= rental_order.rental_item.name_ja %></td>
             <td><%= rental_order.num %></td>
             <td>
-              <%= link_to t('.edit', :default => t("helpers.links.edit")),
-                          edit_rental_order_path(rental_order), :class => 'btn btn-default btn-xs' %>
+              <%= show_edit_botton(edit_rental_order_path(rental_order), rental_order) %>
             </td>
           </tr>
         <% end %>

--- a/app/views/stage_common_options/index.html.erb
+++ b/app/views/stage_common_options/index.html.erb
@@ -24,8 +24,7 @@
         <td><%= stage_common_option.loud_sound.humanize %></td>
         <td><%= stage_common_option.stage_content %></td>
         <td>
-          <%= link_to t('.edit', :default => t("helpers.links.edit")),
-                      edit_stage_common_option_path(stage_common_option), :class => 'btn btn-default btn-xs' %>
+          <%= show_edit_botton(edit_stage_common_option_path(stage_common_option), stage_common_option) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/stage_orders/index.html.erb
+++ b/app/views/stage_orders/index.html.erb
@@ -28,8 +28,7 @@
         <td><%= stage_order.stage_first ? stage_order.kibou1 : "未回答" %></td>
         <td><%= stage_order.stage_second ? stage_order.kibou2 : "未回答" %></td>
         <td>
-          <%= link_to t('.edit', :default => t("helpers.links.edit")),
-                      edit_stage_order_path(stage_order), :class => 'btn btn-default btn-xs' %>
+          <%= show_edit_botton(edit_stage_order_path(stage_order), stage_order) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/sub_reps/index.html.erb
+++ b/app/views/sub_reps/index.html.erb
@@ -30,19 +30,16 @@
         <td><%= sub_rep.tel %></td>
         <td><%= sub_rep.email %></td>
         <td>
-          <%= link_to t('.edit', :default => t("helpers.links.edit")),
-                      edit_sub_rep_path(sub_rep), :class => 'btn btn-default btn-xs' %>
-          <%= link_to t('.destroy', :default => t("helpers.links.destroy")),
-                      sub_rep_path(sub_rep),
-                      :method => :delete,
-                      :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
-                      :class => 'btn btn-xs btn-danger' %>
+          <%= link_to t('.detail', :default => t("helpers.links.show")),
+                      sub_rep_path(sub_rep), :class => 'btn btn-default btn-xs' %>
+          <%= show_edit_botton(edit_sub_rep_path(sub_rep), sub_rep) %>
+          <%= show_destroy_botton(sub_rep_path(sub_rep), sub_rep) %>
         </td>
       </tr>
     <% end %>
   </tbody>
 </table>
 
-<%= link_to t('.new', :default => t("helpers.links.new")),
-            new_sub_rep_path,
-            :class => 'btn btn-primary' %>
+<%= link_to t('.back', :default => t("helpers.links.back")),
+              welcome_index_path, :class => 'btn btn-default'  %>
+<%= show_new_with_group(SubRep, new_sub_rep_path) %>

--- a/app/views/sub_reps/show.html.erb
+++ b/app/views/sub_reps/show.html.erb
@@ -22,10 +22,5 @@
 
 <%= link_to t('.back', :default => t("helpers.links.back")),
               sub_reps_path, :class => 'btn btn-default'  %>
-<%= link_to t('.edit', :default => t("helpers.links.edit")),
-              edit_sub_rep_path(@sub_rep), :class => 'btn btn-default' %>
-<%= link_to t('.destroy', :default => t("helpers.links.destroy")),
-              sub_rep_path(@sub_rep),
-              :method => 'delete',
-              :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
-              :class => 'btn btn-danger' %>
+<%= show_edit_botton(edit_sub_rep_path(@sub_rep), @sub_rep) %>
+<%= show_destroy_botton(sub_rep_path(@sub_rep), @sub_rep) %>

--- a/app/views/welcome/_panel_group.html.erb
+++ b/app/views/welcome/_panel_group.html.erb
@@ -7,8 +7,5 @@
     <%= link_to t('welcome_controller.index'),
             groups_path,
             :class => 'btn btn-default' %>
-    <%= link_to t('welcome_controller.new'),
-            new_group_path,
-            :class => 'btn btn-primary' %>
   </div>
 </div>

--- a/db/fixtures/config_user_permission.rb
+++ b/db/fixtures/config_user_permission.rb
@@ -1,0 +1,11 @@
+ConfigUserPermission.seed( :id,
+  { id: 1  , form_name: '参加団体'       },
+  { id: 2  , form_name: '副代表'         },
+  { id: 3  , form_name: '物品貸出'       },
+  { id: 4  , form_name: '使用電力'       },
+  { id: 5  , form_name: '実施場所'       },
+  { id: 6  , form_name: 'ステージ利用'   },
+  { id: 7  , form_name: '従業員登録'     },
+  { id: 8  , form_name: '販売食品登録'   },
+  { id: 9  , form_name: '購入リスト登録' },
+)

--- a/db/migrate/20160527094623_create_config_user_permissions.rb
+++ b/db/migrate/20160527094623_create_config_user_permissions.rb
@@ -1,0 +1,11 @@
+class CreateConfigUserPermissions < ActiveRecord::Migration
+  def change
+    create_table :config_user_permissions do |t|
+      t.string :form_name, null: false
+      t.boolean :is_accepting, default: false
+      t.boolean :is_only_show, default: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160515150530) do
+ActiveRecord::Schema.define(version: 20160527094623) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,14 @@ ActiveRecord::Schema.define(version: 20160515150530) do
   add_index "active_admin_comments", ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id", using: :btree
   add_index "active_admin_comments", ["namespace"], name: "index_active_admin_comments_on_namespace", using: :btree
   add_index "active_admin_comments", ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id", using: :btree
+
+  create_table "config_user_permissions", force: :cascade do |t|
+    t.string   "form_name",                    null: false
+    t.boolean  "is_accepting", default: false
+    t.boolean  "is_only_show", default: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+  end
 
   create_table "config_welcome_indices", force: :cascade do |t|
     t.string   "name",                          null: false

--- a/docs/issue38.md
+++ b/docs/issue38.md
@@ -1,0 +1,47 @@
+# [機能追加] 参加団体フォーム受付の制御 #38
+
+[優先度:高]
+参加団体募集フォームの募集状態を制御するための機能追加. 
+募集時期に応じて, 入力/閲覧できる情報を制約する. 
+
+1. cancancanのabilityを書き換える
+2. 募集に必要なviewを書き換える
+
+[受付中], [閲覧可], [使用不可]の3状態を作る.
+
+```
+welcome/indexのカテゴリ単位で, 関連するmodel/viewをまとめて制御する
+```
+
+[issue #38](https://github.com/NUTFes/group-manager/issues/38)
+
+
+# 実装の方針
+
+
+DB上で3状態をつぎのように表現する．
+
+* [受付中]: `(is_accepting, is_only_show) = (true, false)`
+* [閲覧可]: `(is_accepting, is_only_show) = (false, true)`
+* [使用不可]: `(is_accepting, is_only_show) = (false, false)`
+
+
+# モデル生成
+
+```
+bundle exec rails g model ConfigUserPermission form_name:string is_accepting:boolean is_only_show:boolean
+```
+
+```
+      t.string :form_name, null: false
+      t.boolean :is_accepting, default: false
+      t.boolean :is_only_show, default: false
+```
+
+```sh
+$ rake db:migrate
+== 20160527094623 CreateConfigUserPermissions: migrating ======================
+-- create_table(:config_user_permissions)
+   -> 0.0329s
+== 20160527094623 CreateConfigUserPermissions: migrated (0.0330s) =============
+```

--- a/docs/issue38.md
+++ b/docs/issue38.md
@@ -87,3 +87,5 @@ Running via Spring preloader in process 42496
 
 値は設定しないこと (上書きを避けるため)
 
+
+# Abilityモデル 編集

--- a/docs/issue38.md
+++ b/docs/issue38.md
@@ -45,3 +45,24 @@ $ rake db:migrate
    -> 0.0329s
 == 20160527094623 CreateConfigUserPermissions: migrated (0.0330s) =============
 ```
+
+# バリデーション追加
+
+
+```diff
+ class ConfigUserPermission < ActiveRecord::Base
++  validate :valid_boolean_unique
++
++  validates_presence_of :form_name
++  validates_uniqueness_of :form_name
++
++  def valid_boolean_unique
++    return unless [is_accepting, is_only_show].all?  # 全部0なら許可
++    unless [is_accepting, is_only_show].one? # trueは1個のみ
++      errors.add(:is_accepting, "trueは1要素のみにしてください．")
++      errors.add(:is_only_show, "trueは1要素のみにしてください．")
++    end
++  end
++
+ end
+```

--- a/docs/issue38.md
+++ b/docs/issue38.md
@@ -81,3 +81,9 @@ Running via Spring preloader in process 42496
 +  permit_params :form_name, :is_accepting, :is_only_show
 
 ```
+
+
+# seed追加
+
+値は設定しないこと (上書きを避けるため)
+

--- a/docs/issue38.md
+++ b/docs/issue38.md
@@ -46,8 +46,8 @@ $ rake db:migrate
 == 20160527094623 CreateConfigUserPermissions: migrated (0.0330s) =============
 ```
 
-# バリデーション追加
 
+# バリデーション追加
 
 ```diff
  class ConfigUserPermission < ActiveRecord::Base
@@ -65,4 +65,19 @@ $ rake db:migrate
 +  end
 +
  end
+```
+
+
+# adminへ追加
+
+```sh
+$ bundle exec rails g active_admin:resource ConfigUserPermission
+Running via Spring preloader in process 42496
+      create  app/admin/config_user_permission.rb
+```
+
+```diff
+
++  permit_params :form_name, :is_accepting, :is_only_show
+
 ```

--- a/docs/issue38.md
+++ b/docs/issue38.md
@@ -89,3 +89,11 @@ Running via Spring preloader in process 42496
 
 
 # Abilityモデル 編集
+
+
+# view 修正
+
+## group
+
+newボタン -> GroupHelperへ
+edit, destroyボタン -> ApplicationHelperへ

--- a/docs/issue38.md
+++ b/docs/issue38.md
@@ -97,3 +97,8 @@ Running via Spring preloader in process 42496
 
 newボタン -> GroupHelperへ
 edit, destroyボタン -> ApplicationHelperへ
+
+## SubRep
+
+newボタン -> ApplicationHelper, show_new_with_groupへ
+edit, destroyボタン -> ApplicationHelperで共用

--- a/docs/issue38.md
+++ b/docs/issue38.md
@@ -102,3 +102,5 @@ edit, destroyボタン -> ApplicationHelperへ
 
 newボタン -> ApplicationHelper, show_new_with_groupへ
 edit, destroyボタン -> ApplicationHelperで共用
+
+以下SubRepと同様に修正


### PR DESCRIPTION
issue #38 

DB上で3状態をつぎのように実装．

* [受付中]: `(is_accepting, is_only_show) = (true, false)`
* [閲覧可]: `(is_accepting, is_only_show) = (false, true)`
* [使用不可]: `(is_accepting, is_only_show) = (false, false)`

marge後に必要な処理

```
rake db:migrate
rake db:seed_fu
```

ConfigUserPermissionの各値を手動で設定してください．