### PR TITLE
ステージ団体の電力申請を1000W以上申請できるように改修

### DIFF
--- a/app/models/power_order.rb
+++ b/app/models/power_order.rb
@@ -2,9 +2,23 @@ class PowerOrder < ActiveRecord::Base
   belongs_to :group
 
   validates :group_id, :item, :power, :manufacturer, :model, presence: true # 必須項目
-  validates :power, numericality: { # 整数のみ, [1-1000]
-    only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 1000,
+
+  def stage?
+    group_category = Group.find(group_id).group_category_id
+    if 3 == group_category
+      return true
+    end
+    return false
+  end
+
+
+  validates :power,     if: :stage?, numericality: { 
+    only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 2500,
   }
+
+  validates :power, unless: :stage?, numericality: { 
+    only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 1000,
+  } 
 
   validates_with PowerOrderCreateValidator, on: :create
   validates_with PowerOrderUpdateValidator, on: :update

--- a/app/validators/power_order_create_validator.rb
+++ b/app/validators/power_order_create_validator.rb
@@ -6,10 +6,18 @@ class PowerOrderCreateValidator < ActiveModel::Validator
     # 保存されている使用電力の合計
     recorded_sum = PowerOrder.where(group_id: record.group_id).sum(:power)
 
+    # ステージ団体は2500W, その他は1000W
+    limit_power = stage?(record.group_id) ? 2500 : 1000
+
     # 追加される電力と合計して1000を超えたらエラー
-    if (record.power + recorded_sum) > 1000
-      msg = "団体が使用する電力の合計が1000[W]を超えています (#{recorded_sum}[W]が申請済み)．"
+    if (record.power + recorded_sum) > limit_power 
+      msg = "団体が使用する電力の合計が#{limit_power}[W]を超えています (#{recorded_sum}[W]が申請済み)．"
       record.errors[:power] << msg
     end
+  end
+
+  def stage?(group_id)
+    return true if 3 == Group.find(group_id).group_category_id
+    return false
   end
 end

--- a/app/validators/power_order_update_validator.rb
+++ b/app/validators/power_order_update_validator.rb
@@ -9,10 +9,18 @@ class PowerOrderUpdateValidator < ActiveModel::Validator
     # 更新前の電力量を引く
     all_without_updated = all - PowerOrder.find(record.id).power
 
+    # ステージ団体は2500W, その他は1000W
+    limit_power = stage?(record.group_id) ? 2500 : 1000
+
     # 追加される電力と合計して1000を超えたらエラー
-    if (all_without_updated + record.power) > 1000
-      msg = "団体が使用する電力の合計が1000[W]を超えています (#{all_without_updated}[W]が申請済み)．"
+    if (all_without_updated + record.power) > limit_power
+      msg = "団体が使用する電力の合計が#{limit_power}[W]を超えています (#{all_without_updated}[W]が申請済み)．"
       record.errors[:power] << msg
     end
+  end
+
+  def stage?(group_id)
+    return true if 3 == Group.find(group_id).group_category_id
+    return false
   end
 end

--- a/app/views/welcome/_panel_power_order.html.erb
+++ b/app/views/welcome/_panel_power_order.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="panel-body">
     電力を使用する団体はこちらから申請して下さい。<br>
-    対象: 参加形式が「模擬店(食品販売，物品販売)」，「展示・体験」，「その他」の団体
+    対象: 全ての参加形式
     <%= link_to t('welcome_controller.index'),
             power_orders_path,
             :class => 'btn btn-default' %>

--- a/config/locales/03_views/ja.yml
+++ b/config/locales/03_views/ja.yml
@@ -17,7 +17,7 @@ ja:
   power_orders:
     form:
       hint_item: 例）炊飯器，ホットプレート
-      hint_power: 機器が使用する電力を入力して下さい．1団体が使用可能な電力は全ての機器で合計して1000[W]です．
+      hint_power: 機器の電力を入力して下さい．1団体が使用可能な電力は全機器の合計で1000[W](ステージ団体:2500[W])です．
       hint_manufacturer: 機器の製造メーカを入力してください．例) YAMAZEN
       hint_model: 機器の型番を入力してください．例) HGB-1300
     show:


### PR DESCRIPTION
fix #127
fix #129

PowerOrderのvalidateにステージに関する記述を追加.
ステージ団体の場合は2500Wまで申請が可能に. 