### PR TITLE
Gemfile.lockの不備を修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,7 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     orm_adapter (0.5.0)
+    pdfkit (0.8.2)
     pg (0.18.1)
     polyamorous (1.1.0)
       activerecord (>= 3.0)


### PR DESCRIPTION
pdfkitに関する記述が抜けていたので補完