### PR TITLE
テストデータを隠蔽する

### DIFF
--- a/db/fixtures/fes_year_date.rb
+++ b/db/fixtures/fes_year_date.rb
@@ -5,6 +5,7 @@ FesYear.seed( :id,
   { id: 4, fes_year: '2018', } ,
   { id: 5, fes_year: '2019', } ,
   { id: 6, fes_year: '2020', } ,
+  { id: 100,fes_year: '10001', } ,
 )
 
 FesDate.seed( :id,

--- a/lib/tasks/set_year_to_groups.rake
+++ b/lib/tasks/set_year_to_groups.rake
@@ -11,4 +11,14 @@ namespace :set_year_to_groups do
       group.save
     }
   end
+
+  # テストデータを隠蔽する(10001年に紐付け)
+  task hide_test_data: :environment do
+    test_group = Group.joins(:user).where( \
+                   groups: {fes_year_id: FesYear.this_year.id}) \
+                    .where(users: {role_id: (1..2)})
+    
+    test_group.update_all(fes_year_id: 100)
+  end
+
 end


### PR DESCRIPTION
fix #154 

年度テーブルのシードに 適当なidの年度(e.g. 10001年)を追加して,
テストデータの年度を書き換えるスクリプトを書きました. 

develop環境では特に実行の必要はない.

マージ後, 実行が必要なコマンド

```
$ bundle exec rake set_year_to_groups:hide_test_data
```
