### PR TITLE
検便書類[検便業者用]のレイアウトが崩れる

### DIFF
--- a/app/helpers/stool_test_pages_helper.rb
+++ b/app/helpers/stool_test_pages_helper.rb
@@ -6,13 +6,20 @@ module StoolTestPagesHelper
     end
   end
 
-  def count_in_group(group_id)
-    @employees.where(group_id: group_id).size
+  def count_in_group(employees, group_id)
+    if employees.class == Employee::ActiveRecord_Relation then
+      employees.where(group_id: group_id).size
+    else
+      Employee.where(id: @employees_uniq).where(group_id: group_id).size
+    end
   end
 
-  def is_next_group(employee, index)
-    @employees = @employees.order(:group_id, :student_id)
-    if @employees[index - 1].group_id != employee.group_id then
+  def is_next_group(employees, employee, index)
+    if employees.class == Array then
+      employees = Employee.where(id: employees)
+    end
+    employees = employees.order(:group_id, :student_id)
+    if employees[index - 1].group_id != employee.group_id then
       true
     else
       false

--- a/app/views/stool_test_pages/check_sheet.pdf.erb
+++ b/app/views/stool_test_pages/check_sheet.pdf.erb
@@ -39,11 +39,11 @@
         <tbody>
   <% end %>
           <tr>
-            <% if is_next_group(employee, i) then %>
+            <% if is_next_group(@employees, employee, i) then %>
               <% employee_count = 0 %>
-              <td rowspan= <%= count_in_group(employee.group_id) %>><%= employee.group.name %></td>
+              <td rowspan= <%= count_in_group(@employees, employee.group_id) %>><%= employee.group.name %></td>
             <% elsif i % rows_per_page == 0 then %>
-              <td rowspan= <%= count_in_group(employee.group_id) - employee_count %>><%= employee.group.name %></td>
+              <td rowspan= <%= count_in_group(@employees, employee.group_id) - employee_count %>><%= employee.group.name %></td>
             <% end %>
             <td><%= employee.student_id %></td>
             <td style="font-size : <%= size_calibration(employee.name) %>"><%= employee.name %></td>

--- a/app/views/stool_test_pages/for_examiner_sheet.pdf.erb
+++ b/app/views/stool_test_pages/for_examiner_sheet.pdf.erb
@@ -34,11 +34,11 @@
         <tbody>
   <% end %>
           <tr>
-            <% if is_next_group(employee, i) then %>
+            <% if is_next_group(@employees_uniq, employee, i) then %>
               <% employee_count = 0 %>
-              <td rowspan= <%= count_in_group(employee.group_id) %>><%= employee.group.name %></td>
+              <td rowspan= <%= count_in_group(@employees_uniq, employee.group_id) %>><%= employee.group.name %></td>
             <% elsif i % rows_per_page == 0 then %>
-              <td rowspan= <%= count_in_group(employee.group_id) - employee_count %>><%= employee.group.name %></td>
+              <td rowspan= <%= count_in_group(@employees_uniq, employee.group_id) - employee_count %>><%= employee.group.name %></td>
             <% end %>
             <td style="font-size : <%= size_calibration(employee.name) %>"><%= employee.name %></td>
             <% employee_count += 1 %>

--- a/app/views/stool_test_pages/for_health_center_sheet.pdf.erb
+++ b/app/views/stool_test_pages/for_health_center_sheet.pdf.erb
@@ -37,11 +37,11 @@
         <tbody>
   <% end %>
           <tr>
-            <% if is_next_group(employee, i) then %>
+            <% if is_next_group(@employees, employee, i) then %>
               <% employee_count = 0 %>
-              <td rowspan= <%= count_in_group(employee.group_id) %>><%= employee.group.name %></td>
+              <td rowspan= <%= count_in_group(@employees, employee.group_id) %>><%= employee.group.name %></td>
             <% elsif i % rows_per_page == 0 then %>
-              <td rowspan= <%= count_in_group(employee.group_id) - employee_count %>><%= employee.group.name %></td>
+              <td rowspan= <%= count_in_group(@employees, employee.group_id) - employee_count %>><%= employee.group.name %></td>
             <% end %>
             <td style="font-size : <%= size_calibration(employee.name) %>"><%= employee.name %></td>
             <td><%= employee.employee_category.to_s %></td>


### PR DESCRIPTION
#159

検便書類[検便業者用]のレイアウトが崩れる問題を修正
- 従業員すべてと，学籍番号でuniqな従業員一覧を区別していなかったため，helperメソッド内で意図しない動作をしていたことが原因
