### PR TITLE
参加団体のメーリングリストCSV出力機能追加

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -56,6 +56,14 @@ ActiveAdmin.register_page "Dashboard" do
       end
     end
 
+    columns do
+      column do
+        panel "代表者一覧" do
+          li link_to('[ダウンロード] 参加団体メーリングリスト', download_group_list_admin_groups_path(format: 'csv'))
+        end
+      end
+    end
+
   end # content
 
 end

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -32,4 +32,22 @@ ActiveAdmin.register Group do
     column :created_at
     column :updated_at
   end
+
+  # csvダウンロードアクションを作成
+  collection_action :download_group_list, :method => :get do
+    groups = Group.where({ fes_year_id: FesYear.this_year() })
+    csv = CSV.generate do |csv|
+      csv << ['Name', 'E-mail Address']
+      groups.each do |group|
+        groupname = group.name + '( ' + group.user.user_detail.name_ja + ' )'
+        csv << [
+          groupname,
+          group.user.email
+        ]
+      end
+    end
+
+    send_data csv.encode('Shift_JIS', :invalid => :replace, :undef => :replace), type: 'text/csv; charset=shift_jis; header=present', disposition: "attachment; filename=group_list.csv"
+  end
+
 end


### PR DESCRIPTION
#176

Gmailでインポートできる形式で参加団体の

- 団体名
- 代表者名
- メールアドレス

を出力する機能を追加


管理者ページのダッシュボード最下部のリンクよりダウンロード