### PR TITLE
管理画面の団体絞込検索を年度で区切って表示，団体をテキストで検索できるように

### DIFF
--- a/app/admin/assign_group_place.rb
+++ b/app/admin/assign_group_place.rb
@@ -28,4 +28,7 @@ ActiveAdmin.register AssignGroupPlace do
     f.actions
   end
 
+  preserve_default_filters!
+  filter :fes_year
+
 end

--- a/app/admin/assign_group_place.rb
+++ b/app/admin/assign_group_place.rb
@@ -30,5 +30,7 @@ ActiveAdmin.register AssignGroupPlace do
 
   preserve_default_filters!
   filter :fes_year
+  filter :group_name, as: :string
+  filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection([1,2,5,4])} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
 
 end

--- a/app/admin/assign_rental_item.rb
+++ b/app/admin/assign_rental_item.rb
@@ -22,4 +22,7 @@ ActiveAdmin.register AssignRentalItem do
     actions
   end
 
+  preserve_default_filters!
+  filter :fes_year
+
 end

--- a/app/admin/assign_rental_item.rb
+++ b/app/admin/assign_rental_item.rb
@@ -24,5 +24,7 @@ ActiveAdmin.register AssignRentalItem do
 
   preserve_default_filters!
   filter :fes_year
+  filter :group_name, as: :string
+  filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(0)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
 
 end

--- a/app/admin/assign_stage.rb
+++ b/app/admin/assign_stage.rb
@@ -55,6 +55,10 @@ ActiveAdmin.register AssignStage do
     end
     f.actions
   end
+
+  preserve_default_filters!
+  filter :fes_year
+
 end
 
 def set_time_point

--- a/app/admin/assign_stage.rb
+++ b/app/admin/assign_stage.rb
@@ -58,6 +58,8 @@ ActiveAdmin.register AssignStage do
 
   preserve_default_filters!
   filter :fes_year
+  filter :group_name, as: :string
+  filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(3)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
 
 end
 

--- a/app/admin/employee.rb
+++ b/app/admin/employee.rb
@@ -26,4 +26,7 @@ ActiveAdmin.register Employee do
     column :duplication
   end
 
+  preserve_default_filters!
+  filter :fes_year
+
 end

--- a/app/admin/employee.rb
+++ b/app/admin/employee.rb
@@ -28,5 +28,7 @@ ActiveAdmin.register Employee do
 
   preserve_default_filters!
   filter :fes_year
+  filter :group_name, as: :string
+  filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(1)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
 
 end

--- a/app/admin/food_product.rb
+++ b/app/admin/food_product.rb
@@ -30,4 +30,7 @@ ActiveAdmin.register FoodProduct do
     end
   end
 
+  preserve_default_filters!
+  filter :fes_year
+
 end

--- a/app/admin/food_product.rb
+++ b/app/admin/food_product.rb
@@ -32,5 +32,7 @@ ActiveAdmin.register FoodProduct do
 
   preserve_default_filters!
   filter :fes_year
+  filter :group_name, as: :string
+  filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(1)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
 
 end

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -61,6 +61,9 @@ ActiveAdmin.register Group do
     active_admin_comments
   end
 
+  preserve_default_filters!
+  filter :fes_year
+
   # csvダウンロードアクションを作成
   collection_action :download_group_list, :method => :get do
     groups = Group.where({ fes_year_id: FesYear.this_year() })

--- a/app/admin/group_project_name.rb
+++ b/app/admin/group_project_name.rb
@@ -18,4 +18,8 @@ ActiveAdmin.register GroupProjectName do
     end
     actions
   end
+
+  preserve_default_filters!
+  filter :fes_year
+
 end

--- a/app/admin/group_project_name.rb
+++ b/app/admin/group_project_name.rb
@@ -21,5 +21,7 @@ ActiveAdmin.register GroupProjectName do
 
   preserve_default_filters!
   filter :fes_year
+  filter :group_name, as: :string
+  filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(0)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
 
 end

--- a/app/admin/place_order.rb
+++ b/app/admin/place_order.rb
@@ -32,4 +32,8 @@ ActiveAdmin.register PlaceOrder do
     end
     column :remark
   end
+
+  preserve_default_filters!
+  filter :fes_year
+
 end

--- a/app/admin/place_order.rb
+++ b/app/admin/place_order.rb
@@ -35,5 +35,7 @@ ActiveAdmin.register PlaceOrder do
 
   preserve_default_filters!
   filter :fes_year
+  filter :group_name, as: :string
+  filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection([1,2,5,4])} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
 
 end

--- a/app/admin/power_order.rb
+++ b/app/admin/power_order.rb
@@ -25,4 +25,7 @@ ActiveAdmin.register PowerOrder do
     column :model
   end
 
+  preserve_default_filters!
+  filter :fes_year
+
 end

--- a/app/admin/power_order.rb
+++ b/app/admin/power_order.rb
@@ -27,5 +27,7 @@ ActiveAdmin.register PowerOrder do
 
   preserve_default_filters!
   filter :fes_year
+  filter :group_name, as: :string
+  filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(0)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
 
 end

--- a/app/admin/purchase_list.rb
+++ b/app/admin/purchase_list.rb
@@ -38,5 +38,7 @@ ActiveAdmin.register PurchaseList do
     column :items
   end
 
+  preserve_default_filters!
+  filter :fes_year
 
 end

--- a/app/admin/purchase_list.rb
+++ b/app/admin/purchase_list.rb
@@ -40,5 +40,7 @@ ActiveAdmin.register PurchaseList do
 
   preserve_default_filters!
   filter :fes_year
+  filter :group_name, as: :string
+  filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(0)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
 
 end

--- a/app/admin/rental_order.rb
+++ b/app/admin/rental_order.rb
@@ -34,4 +34,8 @@ ActiveAdmin.register RentalOrder do
     end
     column :num
   end
+
+  preserve_default_filters!
+  filter :fes_year
+
 end

--- a/app/admin/rental_order.rb
+++ b/app/admin/rental_order.rb
@@ -37,5 +37,7 @@ ActiveAdmin.register RentalOrder do
 
   preserve_default_filters!
   filter :fes_year
+  filter :group_name, as: :string
+  filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(0)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
 
 end

--- a/app/admin/stage_common_option.rb
+++ b/app/admin/stage_common_option.rb
@@ -39,5 +39,7 @@ ActiveAdmin.register StageCommonOption do
     column :stage_content
   end
 
+  preserve_default_filters!
+  filter :fes_year
 
 end

--- a/app/admin/stage_common_option.rb
+++ b/app/admin/stage_common_option.rb
@@ -41,5 +41,7 @@ ActiveAdmin.register StageCommonOption do
 
   preserve_default_filters!
   filter :fes_year
+  filter :group_name, as: :string
+  filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(3)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
 
 end

--- a/app/admin/stage_order.rb
+++ b/app/admin/stage_order.rb
@@ -88,4 +88,8 @@ ActiveAdmin.register StageOrder do
     end
     active_admin_comments
   end
+
+  preserve_default_filters!
+  filter :fes_year
+
 end

--- a/app/admin/stage_order.rb
+++ b/app/admin/stage_order.rb
@@ -2,7 +2,6 @@ ActiveAdmin.register StageOrder do
 
   permit_params :group_id, :fes_date_id, :is_sunny, :stage_first, :stage_second, :time_point_start, :time_point_end, :time_interval
 
-
   index do
     selectable_column
     id_column
@@ -91,5 +90,7 @@ ActiveAdmin.register StageOrder do
 
   preserve_default_filters!
   filter :fes_year
+  filter :group_name, as: :string
+  filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(3)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
 
 end

--- a/app/admin/sub_rep.rb
+++ b/app/admin/sub_rep.rb
@@ -25,4 +25,8 @@ ActiveAdmin.register SubRep do
     column :email
     actions
   end
+
+  preserve_default_filters!
+  filter :fes_year
+
 end

--- a/app/admin/sub_rep.rb
+++ b/app/admin/sub_rep.rb
@@ -28,5 +28,7 @@ ActiveAdmin.register SubRep do
 
   preserve_default_filters!
   filter :fes_year
+  filter :group_name, as: :string
+  filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(0)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
 
 end

--- a/app/models/assign_group_place.rb
+++ b/app/models/assign_group_place.rb
@@ -1,6 +1,8 @@
 class AssignGroupPlace < ActiveRecord::Base
   belongs_to :place_order
   belongs_to :place
+  has_one :fes_year, through: :place_order
+
   validates_presence_of :place_order_id, :place_id
   validates :place_order_id, uniqueness: {scope: [:place_id] }
 

--- a/app/models/assign_group_place.rb
+++ b/app/models/assign_group_place.rb
@@ -2,6 +2,7 @@ class AssignGroupPlace < ActiveRecord::Base
   belongs_to :place_order
   belongs_to :place
   has_one :fes_year, through: :place_order
+  has_one :group, through: :place_order
 
   validates_presence_of :place_order_id, :place_id
   validates :place_order_id, uniqueness: {scope: [:place_id] }

--- a/app/models/assign_rental_item.rb
+++ b/app/models/assign_rental_item.rb
@@ -1,6 +1,7 @@
 class AssignRentalItem < ActiveRecord::Base
   belongs_to :rental_order
   belongs_to :rentable_item
+  has_one :fes_year, through: :rental_order
 
   validates_presence_of :rental_order_id, :rentable_item_id, :num
   validates :num, numericality: {only_integer: true, greater_than_or_equal_to: 0}

--- a/app/models/assign_rental_item.rb
+++ b/app/models/assign_rental_item.rb
@@ -2,6 +2,7 @@ class AssignRentalItem < ActiveRecord::Base
   belongs_to :rental_order
   belongs_to :rentable_item
   has_one :fes_year, through: :rental_order
+  has_one :group, through: :rental_order
 
   validates_presence_of :rental_order_id, :rentable_item_id, :num
   validates :num, numericality: {only_integer: true, greater_than_or_equal_to: 0}

--- a/app/models/assign_stage.rb
+++ b/app/models/assign_stage.rb
@@ -1,6 +1,7 @@
 class AssignStage < ActiveRecord::Base
   belongs_to :stage_order
   belongs_to :stage
+  has_one :fes_year, through: :stage_order
 
   validates_presence_of :stage_order_id, :stage_id
   validate :time_is_only_selected, :start_to_end

--- a/app/models/assign_stage.rb
+++ b/app/models/assign_stage.rb
@@ -2,6 +2,7 @@ class AssignStage < ActiveRecord::Base
   belongs_to :stage_order
   belongs_to :stage
   has_one :fes_year, through: :stage_order
+  has_one :group, through: :stage_order
 
   validates_presence_of :stage_order_id, :stage_id
   validate :time_is_only_selected, :start_to_end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -2,6 +2,7 @@ class Employee < ActiveRecord::Base
   belongs_to :group
   belongs_to :employee_category
   has_many :food_products, through: :group
+  has_one :fes_year, through: :group
 
   # before_save :give_duplication
   # before_destroy :remove_duplication # レコードのdelete後に実行

--- a/app/models/food_product.rb
+++ b/app/models/food_product.rb
@@ -2,6 +2,7 @@ class FoodProduct < ActiveRecord::Base
   belongs_to :group
   has_many :purchase_list
   has_many :employees, through: :group
+  has_one :fes_year, through: :group
 
   validates_presence_of :group_id, :name, :first_day_num, :second_day_num
   validates_numericality_of :group_id, :first_day_num, :second_day_num

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -13,6 +13,22 @@ class Group < ActiveRecord::Base
   validates :fes_year, presence: true
 
   scope :year, -> (year) {where(fes_year_id: year)}
+  scope :active_admin_collection, -> (group_category_id) { # ActiveAdminのフィルター用コレクション, group_category_id: 0ですべてのグループを取得
+    fes_years = FesYear.all.order("id DESC") # 降順ですべてのFesYearを取得
+    groups = []
+    fes_years.each do |fes_year|
+      the_year_groups = Group.where(fes_year: fes_year)
+                             .order('name COLLATE "C" ASC') # その年のグループを取得.日本語ソート（漢字は無理）
+      if group_category_id != 0
+        the_year_groups = the_year_groups.where(group_category_id: group_category_id)
+      end
+      if the_year_groups.blank? == false
+        groups.push( Group.new(id: nil, name: "---------------------" + fes_year.to_s.to_s + "---------------------") ) # セパレータを追加
+        the_year_groups.each {|group| groups.push(group)}
+      end
+    end
+    groups
+  }
 
   # simple_form, activeadminで表示するカラムを指定
   # 関連モデル.groupが関連モデル.group.nameと同等になる

--- a/app/models/group_project_name.rb
+++ b/app/models/group_project_name.rb
@@ -1,5 +1,6 @@
 class GroupProjectName < ActiveRecord::Base
   belongs_to :group
+  has_one :fes_year, through: :group
 
   validates_presence_of :project_name, :project_name
   validates_numericality_of :group_id

--- a/app/models/place_order.rb
+++ b/app/models/place_order.rb
@@ -1,5 +1,7 @@
 class PlaceOrder < ActiveRecord::Base
   belongs_to :group
+  has_one :fes_year, through: :group
+
   validate :select_different_stage
   validate :write_remark
 

--- a/app/models/power_order.rb
+++ b/app/models/power_order.rb
@@ -1,5 +1,6 @@
 class PowerOrder < ActiveRecord::Base
   belongs_to :group
+  has_one :fes_year, through: :group
 
   validates :group_id, :item, :power, :manufacturer, :model, presence: true # 必須項目
 

--- a/app/models/purchase_list.rb
+++ b/app/models/purchase_list.rb
@@ -2,6 +2,7 @@ class PurchaseList < ActiveRecord::Base
   belongs_to :food_product
   belongs_to :shop
   belongs_to :fes_date
+  has_one :fes_year, through: :food_product
 
   validates_presence_of :food_product_id, :shop_id, :fes_date_id, :items
   validates :food_product_id, uniqueness: {scope: [:shop_id, :fes_date_id]}

--- a/app/models/purchase_list.rb
+++ b/app/models/purchase_list.rb
@@ -3,6 +3,7 @@ class PurchaseList < ActiveRecord::Base
   belongs_to :shop
   belongs_to :fes_date
   has_one :fes_year, through: :food_product
+  has_one :group, through: :food_product
 
   validates_presence_of :food_product_id, :shop_id, :fes_date_id, :items
   validates :food_product_id, uniqueness: {scope: [:shop_id, :fes_date_id]}

--- a/app/models/rental_order.rb
+++ b/app/models/rental_order.rb
@@ -2,6 +2,7 @@ class RentalOrder < ActiveRecord::Base
   belongs_to :group
   belongs_to :rental_item
   has_many :assign_rental_item
+  has_one :fes_year, through: :group
 
   validates :group_id, :rental_item_id, :num, presence: true
   validates :num, numericality: {

--- a/app/models/stage_common_option.rb
+++ b/app/models/stage_common_option.rb
@@ -1,5 +1,6 @@
 class StageCommonOption < ActiveRecord::Base
   belongs_to :group
+  has_one :fes_year, through: :group
 
   # 存在チェック
   validates :group_id, :stage_content, presence: true

--- a/app/models/stage_order.rb
+++ b/app/models/stage_order.rb
@@ -1,6 +1,7 @@
 class StageOrder < ActiveRecord::Base
   belongs_to :group
   belongs_to :fes_date
+  has_one :fes_year, through: :fes_date
 
   validates :group_id, :fes_date_id, presence: true
   validates :group_id, :uniqueness => {:scope => [:fes_date_id, :is_sunny] } # 日付と天候でユニーク

--- a/app/models/sub_rep.rb
+++ b/app/models/sub_rep.rb
@@ -2,6 +2,7 @@ class SubRep < ActiveRecord::Base
   belongs_to :group
   belongs_to :department
   belongs_to :grade
+  has_one :fes_year, through: :group
 
   # 必須入力
   validates :group_id, :name_ja, :name_en, :tel, :email, :department_id, :grade_id,

--- a/docs/issue204.md
+++ b/docs/issue204.md
@@ -1,0 +1,57 @@
+# issue204
+
+管理画面で年度項目の絞込検索できるようにする
+
+# 対応ページ一覧
+
+- StageOrder
+- StageCommonOption
+- GroupProjectName
+- AssignStage
+- AssignGroupPlace
+- PowerOrder
+- SubRep
+- Group
+- PlaceOrder
+- Employee
+- RentalOrder
+- FoodProduct
+- AssignRentalItem
+
+# 年度絞込項目の追加
+
+`FesYear` モデルとアソシエーションが設定されていないモデルではシンボル `:fes_year` を解決できません．なので，まずはアソシエーションを設定します．
+とりあえず， `StageOrder` の設定例を示します．
+
+
+```diff
+--- a/app/models/stage_order.rb
++++ b/app/models/stage_order.rb
+@@ -1,6 +1,7 @@
+ class StageOrder < ActiveRecord::Base
+    belongs_to :group
+       belongs_to :fes_date
+       +  has_one :fes_year, through: :fes_date
+
+          validates :group_id, :fes_date_id, presence: true
+             validates :group_id, :uniqueness => {:scope => [:fes_date_id, :is_sunny] } # 日付と天候でユニーク
+```
+
+次に管理画面に絞込項目を追加します．
+
+```diff
+--- a/app/admin/stage_order.rb
++++ b/app/admin/stage_order.rb
+@@ -88,4 +88,8 @@ ActiveAdmin.register StageOrder do
+     end
+          active_admin_comments
+             end
+             +
+             +  preserve_default_filters!
+             +  filter :fes_year
+             +
+              end
+```
+
+これで，管理画面に年度絞込項目が追加されました．
+後はこれを繰り返すだけです．


### PR DESCRIPTION
resolve #181 
refer #205

下のように団体のコレクションを年度で区切って表示するように変更
さらに，テキストで検索できるように

![2017-06-30 23 01 28](https://user-images.githubusercontent.com/6219249/27740395-ddf4ea28-5dec-11e7-84c0-29a7ccd77842.png)

本気でやるならJS使って動的にコレクションを変更するのがいいと思います．