### PR TITLE
生物棟エリアの追加

### DIFF
--- a/db/fixtures/place.rb
+++ b/db/fixtures/place.rb
@@ -15,5 +15,6 @@ Place.seed( :id,
   { id: 14 , name_ja: 'マルチメディアセンター' } ,
   { id: 15 , name_ja: 'グラウンド'     },
   { id: 16 , name_ja: '規定外の場所'   },
-  { id: 17 , name_ja: '機械棟エリア'   }
+  { id: 17 , name_ja: '機械棟エリア'   },
+  { id: 18 , name_ja: '生物棟エリア'   }
 )

--- a/db/fixtures/stoker_places.rb
+++ b/db/fixtures/stoker_places.rb
@@ -55,5 +55,5 @@ StockerPlace.seed( :id,
 { id: 54 , name: '課外活動共用施設' , is_available_fesdate: false} ,
 { id: 55 , name: 'セコムホール(北側倉庫)' , } ,
 { id: 56 , name: 'セコムホール(入口側倉庫)' , } ,
-{ id: 56 , name: '本部(福利棟)' ,},
+{ id: 57 , name: '本部(福利棟)' ,},
 )

--- a/db/fixtures/stoker_places.rb
+++ b/db/fixtures/stoker_places.rb
@@ -55,4 +55,5 @@ StockerPlace.seed( :id,
 { id: 54 , name: '課外活動共用施設' , is_available_fesdate: false} ,
 { id: 55 , name: 'セコムホール(北側倉庫)' , } ,
 { id: 56 , name: 'セコムホール(入口側倉庫)' , } ,
+{ id: 56 , name: '本部(福利棟)' ,},
 )


### PR DESCRIPTION
今年度，模擬店が生物棟前まで伸びるため，場所に「生物棟エリア」を追加

必要となる作業
$bundle exec rake db:seed_fu