### PR TITLE
電力の合計値を出力するように

### DIFF
--- a/app/views/group_information_pages/group_information_sheet.pdf.erb
+++ b/app/views/group_information_pages/group_information_sheet.pdf.erb
@@ -55,7 +55,7 @@
     </tr>
     <tr>
       <td>電力</td>
-      <td colspan="2"><%= PowerOrder.where(group_id: group.id).first.try(:power) %> [W]</td>
+      <td colspan="2"><%= PowerOrder.where(group_id: group.id).sum(:power) %> [W]</td>
     </tr>
   </table>
   <br>


### PR DESCRIPTION
物品持出し表（各団体向け）において電力の値がグループで検索したときの最初のレコードを参照していたため，合計値を出すように