### PR TITLE
管理画面「参加団体」で「質問・要望など」を表示

### DIFF
--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -12,6 +12,7 @@ ActiveAdmin.register Group do
     column :group_category
     column :activity
     column :created_at
+    column :first_question
     actions
   end
 


### PR DESCRIPTION
#202

管理画面「参加団体」の一覧に「質問・要望など」のカラムを追加した
文字数が多い場合でも全て表示される
見づらい場合にはいい感じに修正する