### PR TITLE
参加団体の質問要望欄を消す

### DIFF
--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -1,7 +1,6 @@
 ActiveAdmin.register Group do
 
-  permit_params :user_id, :name, :group_category_id, :activity, :first_question,
-                :fes_year_id
+  permit_params :user_id, :name, :group_category_id, :activity, :fes_year_id
 
   index do
     selectable_column
@@ -12,7 +11,6 @@ ActiveAdmin.register Group do
     column :group_category
     column :activity
     column :created_at
-    column :first_question
     actions
   end
 
@@ -54,7 +52,6 @@ ActiveAdmin.register Group do
         group.sub_reps.map(&:tel).join(", ")
       end
       row :activity
-      row :first_question
       row :created_at
       row :updated_at
       row :fes_year_id

--- a/app/views/group_mailer/update.html.erb
+++ b/app/views/group_mailer/update.html.erb
@@ -11,8 +11,6 @@
 <dd><%= @group.group_category.name_ja %></dd>
 <dt><strong><%= model_class.human_attribute_name(:activity) %>:</strong></dt>
 <dd><%= @group.activity %></dd>
-<dt><strong><%= model_class.human_attribute_name(:first_question) %>:</strong></dt>
-<dd><%= @group.first_question %></dd>
 
 </br>
 ------</br>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -15,10 +15,6 @@
     hint: t(".hint_activity")
   %>
   <%= error_span(@group[:activity]) %>
-  <%= f.input :first_question,
-    hint: t(".hint_questions")
-  %>
-  <%= error_span(@group[:first_question]) %>
 
   <%= f.button :submit, :class => 'btn-primary' %>
   <%= link_to t('.cancel', :default => t("helpers.links.cancel")),

--- a/app/views/groups/index.json.jbuilder
+++ b/app/views/groups/index.json.jbuilder
@@ -1,4 +1,4 @@
 json.array!(@groups) do |group|
-  json.extract! group, :id, :name, :group_category_id, :user_id, :activity, :first_question
+  json.extract! group, :id, :name, :group_category_id, :user_id, :activity
   json.url group_url(group, format: :json)
 end

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -10,8 +10,6 @@
   <dd><%= @group.group_category.name_ja %></dd>
   <dt><strong><%= model_class.human_attribute_name(:activity) %>:</strong></dt>
   <dd><%= @group.activity %></dd>
-  <dt><strong><%= model_class.human_attribute_name(:first_question) %>:</strong></dt>
-  <dd><%= @group.first_question %></dd>
 </dl>
 
 <%= link_to t('.back', :default => t("helpers.links.back")),

--- a/app/views/groups/show.json.jbuilder
+++ b/app/views/groups/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @group, :id, :name, :group_category_id, :user_id, :activity, :first_question, :created_at, :updated_at
+json.extract! @group, :id, :name, :group_category_id, :user_id, :activity, :created_at, :updated_at

--- a/config/locales/01_model/ja.yml
+++ b/config/locales/01_model/ja.yml
@@ -30,7 +30,6 @@ ja:
           name: 運営団体の名称
           group_category: 参加形式
           activity: 主な活動内容
-          first_question: 質問・要望など
         group_project_name:
           group: 運営団体の名称
           project_name: 企画名

--- a/db/migrate/20180502131210_remove_first_question_from_groups.rb
+++ b/db/migrate/20180502131210_remove_first_question_from_groups.rb
@@ -1,0 +1,5 @@
+class RemoveFirstQuestionFromGroups < ActiveRecord::Migration
+  def change
+    remove_column :groups, :first_question, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170418070252) do
+ActiveRecord::Schema.define(version: 20180502131210) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -167,7 +167,6 @@ ActiveRecord::Schema.define(version: 20170418070252) do
     t.integer  "group_category_id"
     t.integer  "user_id"
     t.text     "activity"
-    t.text     "first_question"
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
     t.integer  "fes_year_id"


### PR DESCRIPTION
関連：#231
Groupモデルのfirst_questionカラムを削除した

変更の手順
- `bundle exec rails g migration RemoveFirstQuestionFromGroups first_question:string`
- `bundle exec rake db:migrate`
- 関連するviewからfirst_questionを削除

必要な作業
- `bundle exec rake db:migrate`してください