### PR TITLE
ステージ企画の利用場所に「なし」を追加

### DIFF
--- a/db/fixtures/stage.rb
+++ b/db/fixtures/stage.rb
@@ -4,4 +4,5 @@ Stage.seed( :id,
   { id: 3 , name_ja: '体育館'                 , enable_sunny: true,  enable_rainy: true  } ,
   { id: 4 , name_ja: 'マルチメディアセンター' , enable_sunny: true,  enable_rainy: true  } ,
   { id: 5 , name_ja: '武道館'                 , enable_sunny: true,  enable_rainy: true  } ,
+  { id: 6 , name_ja: 'なし'                   , enable_sunny: true,  enable_rainy: true  } ,
 )

--- a/docs/issue242.md
+++ b/docs/issue242.md
@@ -1,0 +1,7 @@
+# issue242
+「Edit ステージ利用の申請」の希望場所「なし」を追加
+
+## 変更点
+db/fixtures/stage.rbに
+`{ id: 6 , name_ja: 'なし'                   , enable_sunny: true,  enable_rainy: true  } ,`
+を追加


### PR DESCRIPTION
関連#242
・変更点
db/fixtures/stage.rbに
`{ id: 6 , name_ja: 'なし'                   , enable_sunny: true,  enable_rainy: true  } ,`
を追加

・実行手順
`bundle exec rake db:seed_fu`