### PR TITLE
管理画面の参加団体詳細ページに関連するデータへのリンクを追加

### DIFF
--- a/app/admin/assign_rental_item.rb
+++ b/app/admin/assign_rental_item.rb
@@ -1,6 +1,7 @@
 ActiveAdmin.register AssignRentalItem do
 
   permit_params :rental_order_id, :rentable_item_id, :num
+  belongs_to :group, optional: true
 
 
   action_item only: :index do

--- a/app/admin/assign_stage.rb
+++ b/app/admin/assign_stage.rb
@@ -1,6 +1,7 @@
 ActiveAdmin.register AssignStage do
 
   permit_params :stage_id, :time_point_start, :time_point_end
+  belongs_to :group, optional: true
 
   index do
     selectable_column

--- a/app/admin/employee.rb
+++ b/app/admin/employee.rb
@@ -1,6 +1,7 @@
 ActiveAdmin.register Employee do
 
   permit_params :group_id, :name, :student_id, :employee_category_id
+  belongs_to :group, optional: true
 
   index do
     selectable_column

--- a/app/admin/food_product.rb
+++ b/app/admin/food_product.rb
@@ -1,6 +1,7 @@
 ActiveAdmin.register FoodProduct do
 
   permit_params :group_id, :name, :num, :is_cooking
+  belongs_to :group, optional: true
 
   index do
     selectable_column

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -61,10 +61,18 @@ ActiveAdmin.register Group do
 
   sidebar "詳細へのリンク", only: [:show] do
     hm_children = Group.reflect_on_all_associations(:has_many) # has_many関係にあるモデルを全て取得
+    ho_children = Group.reflect_on_all_associations(:has_one) # has_one関係にあるモデルを全て取得
 
     ul do
       hm_children.each do |child|
         li link_to child.klass.model_name.human, [:admin, group, child.name]
+      end
+
+      ho_children.each do |child|
+        c = group.send(child.name)
+        if c != nil
+          li link_to child.klass.model_name.human, [:admin, child.klass.find(c.id)] # group.send(child.name)ではなぜかうまくいかないので再度探してくる
+        end
       end
     end
   end

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -65,10 +65,16 @@ ActiveAdmin.register Group do
 
     ul do
       hm_children.each do |child|
+        if child.kind_of?(ActiveRecord::Reflection::ThroughReflection) # throughアソシエーションの場合は中のActiveRecord::Reflection::HasManyReflectionを取得する
+          child = child.delegate_reflection
+        end
         li link_to child.klass.model_name.human, [:admin, group, child.name]
       end
 
       ho_children.each do |child|
+        if child.kind_of?(ActiveRecord::Reflection::ThroughReflection)
+          child = child.delegate_reflection
+        end
         c = group.send(child.name)
         if c != nil
           li link_to child.klass.model_name.human, [:admin, child.klass.find(c.id)] # group.send(child.name)ではなぜかうまくいかないので再度探してくる

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -59,6 +59,16 @@ ActiveAdmin.register Group do
     active_admin_comments
   end
 
+  sidebar "詳細へのリンク", only: [:show] do
+    hm_children = Group.reflect_on_all_associations(:has_many) # has_many関係にあるモデルを全て取得
+
+    ul do
+      hm_children.each do |child|
+        li link_to child.klass.model_name.human, [:admin, group, child.name]
+      end
+    end
+  end
+
   preserve_default_filters!
   filter :fes_year
 

--- a/app/admin/group_project_name.rb
+++ b/app/admin/group_project_name.rb
@@ -1,5 +1,6 @@
 ActiveAdmin.register GroupProjectName do
   permit_params :project_name
+  belongs_to :group, optional: true
 
   index do
     selectable_column

--- a/app/admin/power_order.rb
+++ b/app/admin/power_order.rb
@@ -1,6 +1,7 @@
 ActiveAdmin.register PowerOrder do
 
   permit_params :group_id, :item, :power, :manufacturer, :model
+  belongs_to :group, optional: true
 
   index do
     selectable_column

--- a/app/admin/rental_order.rb
+++ b/app/admin/rental_order.rb
@@ -2,6 +2,7 @@ ActiveAdmin.register RentalOrder do
 
 
   permit_params :num
+  belongs_to :group, optional: true
 
   index do
     selectable_column

--- a/app/admin/stage_order.rb
+++ b/app/admin/stage_order.rb
@@ -1,6 +1,7 @@
 ActiveAdmin.register StageOrder do
 
   permit_params :group_id, :fes_date_id, :is_sunny, :stage_first, :stage_second, :time_point_start, :time_point_end, :time_interval
+  belongs_to :group, optional: true
 
   index do
     selectable_column

--- a/app/admin/sub_rep.rb
+++ b/app/admin/sub_rep.rb
@@ -15,6 +15,7 @@ ActiveAdmin.register SubRep do
 
   permit_params :group_id, :name_ja, :name_en, :department_id, :grade_id, :tel,
                 :email
+  belongs_to :group, optional: true
 
   index do
     selectable_column

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -10,7 +10,7 @@ class Group < ActiveRecord::Base
   has_many :stage_orders, dependent: :destroy
   has_many :group_project_name, dependent: :destroy
   has_one :place_order, dependent: :destroy
-  has_many :stage_common_option, dependent: :destroy
+  has_one :stage_common_option, dependent: :destroy
 
   validates :name, presence: true, uniqueness: { scope: :fes_year }
   validates :user, presence: true

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -8,7 +8,7 @@ class Group < ActiveRecord::Base
   has_many :rental_orders, dependent: :destroy
   has_many :power_orders, dependent: :destroy
   has_many :stage_orders, dependent: :destroy
-  has_many :group_project_name, dependent: :destroy
+  has_many :group_project_names, dependent: :destroy
   has_one :place_order, dependent: :destroy
   has_one :stage_common_option, dependent: :destroy
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -9,8 +9,11 @@ class Group < ActiveRecord::Base
   has_many :power_orders, dependent: :destroy
   has_many :stage_orders, dependent: :destroy
   has_many :group_project_names, dependent: :destroy
+  has_many :assign_stages, through: :stage_orders, dependent: :destroy
+  has_many :assign_rental_items, through: :rental_orders, dependent: :destroy
   has_one :place_order, dependent: :destroy
   has_one :stage_common_option, dependent: :destroy
+  has_one :assign_group_place, through: :place_order, dependent: :destroy
 
   validates :name, presence: true, uniqueness: { scope: :fes_year }
   validates :user, presence: true


### PR DESCRIPTION
resolve #225

右にサイドバーを設置．リンクを踏むと，アソシエーションから辿ったレコードを表示します．

![image](https://user-images.githubusercontent.com/6219249/39572274-826f5198-4f09-11e8-8392-b3c57bef32c4.png)
