### PR TITLE
電力申請時に機器のURLを入力させる

### DIFF
--- a/app/admin/power_order.rb
+++ b/app/admin/power_order.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register PowerOrder do
 
-  permit_params :group_id, :item, :power, :manufacturer, :model
+  permit_params :group_id, :item, :power, :manufacturer, :model, :item_url
   belongs_to :group, optional: true
 
   index do
@@ -11,6 +11,7 @@ ActiveAdmin.register PowerOrder do
     column :power
     column :manufacturer
     column :model
+    column :item_url
     column :updated_at
     actions
   end
@@ -24,6 +25,7 @@ ActiveAdmin.register PowerOrder do
     column :power
     column :manufacturer
     column :model
+    column :item_url
   end
 
   preserve_default_filters!

--- a/app/controllers/power_orders_controller.rb
+++ b/app/controllers/power_orders_controller.rb
@@ -76,7 +76,7 @@ class PowerOrdersController < GroupBase
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def power_order_params
-      params.require(:power_order).permit(:group_id, :item, :power, :manufacturer, :model)
+      params.require(:power_order).permit(:group_id, :item, :power, :manufacturer, :model, :item_url)
     end
 
     def set_groups

--- a/app/models/power_order.rb
+++ b/app/models/power_order.rb
@@ -25,7 +25,8 @@ class PowerOrder < ActiveRecord::Base
   } 
 
   def is_correct_url
-    return if item_url.match(%r(\Ahttps?://[\w/:%#\$&\?\(\)~\.=\+\-]+\z))
+    # 正しいURLか'なし'の場合を許可
+    return if item_url.match(%r(\Ahttps?://[\w/:%#\$&\?\(\)~\.=\+\-]+\z)) or item_url == 'なし'
     errors.add( :item_url, "正しいURLを入力してください" )
   end
 

--- a/app/models/power_order.rb
+++ b/app/models/power_order.rb
@@ -25,7 +25,7 @@ class PowerOrder < ActiveRecord::Base
   } 
 
   def is_correct_url
-    return if item_url.match(%r(https?://[\w/:%#\$&\?\(\)~\.=\+\-]+))
+    return if item_url.match(%r(\Ahttps?://[\w/:%#\$&\?\(\)~\.=\+\-]+\z))
     errors.add( :item_url, "正しいURLを入力してください" )
   end
 

--- a/app/models/power_order.rb
+++ b/app/models/power_order.rb
@@ -2,7 +2,8 @@ class PowerOrder < ActiveRecord::Base
   belongs_to :group
   has_one :fes_year, through: :group
 
-  validates :group_id, :item, :power, :manufacturer, :model, presence: true # 必須項目
+  validates :group_id, :item, :power, :manufacturer, :model, :item_url, presence: true # 必須項目
+  validate :is_correct_url
 
   scope :year, -> (year) {joins(:group).where(groups: {fes_year_id: year})}
 
@@ -15,13 +16,18 @@ class PowerOrder < ActiveRecord::Base
   end
 
 
-  validates :power,     if: :stage?, numericality: { 
+  validates :power, if: :stage?, numericality: {
     only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 2500,
   }
 
-  validates :power, unless: :stage?, numericality: { 
+  validates :power, unless: :stage?, numericality: {
     only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 1000,
   } 
+
+  def is_correct_url
+    return if item_url.match(%r(https?://[\w/:%#\$&\?\(\)~\.=\+\-]+))
+    errors.add( :item_url, "正しいURLを入力してください" )
+  end
 
   validates_with PowerOrderCreateValidator, on: :create
   validates_with PowerOrderUpdateValidator, on: :update

--- a/app/views/power_orders/_form.html.erb
+++ b/app/views/power_orders/_form.html.erb
@@ -18,6 +18,11 @@
   %>
   <%= error_span(@power_order[:model]) %>
 
+  <%=f.input :item_url,
+    hint: t(".hint_item_url")
+  %>
+  <%= error_span(@power_order[:item_url]) %>
+
   <%= f.button :submit, :class => 'btn-primary' %>
   <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
                 power_orders_path, :class => 'btn btn-default' %>

--- a/app/views/power_orders/index.html.erb
+++ b/app/views/power_orders/index.html.erb
@@ -10,6 +10,7 @@
       <th><%= model_class.human_attribute_name(:power) %></th>
       <th><%= model_class.human_attribute_name(:manufacturer) %></th>
       <th><%= model_class.human_attribute_name(:model) %></th>
+      <th><%= model_class.human_attribute_name(:item_url) %></th>
       <th><%=t '.actions', :default => t("helpers.actions") %></th>
     </tr>
   </thead>
@@ -21,6 +22,7 @@
         <td><%= power_order.power %></td>
         <td><%= power_order.manufacturer %></td>
         <td><%= power_order.model %></td>
+        <td><%= power_order.item_url %></td>
         <td>
           <%= show_edit_botton(edit_power_order_path(power_order), power_order) %>
           <%= show_destroy_botton(power_order_path(power_order), power_order) %>

--- a/app/views/power_orders/index.json.jbuilder
+++ b/app/views/power_orders/index.json.jbuilder
@@ -1,4 +1,4 @@
 json.array!(@power_orders) do |power_order|
-  json.extract! power_order, :id, :group_id, :item, :power
+  json.extract! power_order, :id, :group_id, :item, :power, :item_url
   json.url power_order_url(power_order, format: :json)
 end

--- a/app/views/power_orders/show.html.erb
+++ b/app/views/power_orders/show.html.erb
@@ -14,6 +14,8 @@
   <dd><%= @power_order.manufacturer %></dd>
   <dt><strong><%= model_class.human_attribute_name(:model) %>:</strong></dt>
   <dd><%= @power_order.model %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:item_url) %>:</strong></dt>
+  <dd><%= @power_order.item_url %></dd>
 </dl>
 
 <%= link_to t('.back', :default => t("helpers.links.back")),

--- a/app/views/power_orders/show.json.jbuilder
+++ b/app/views/power_orders/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @power_order, :id, :group_id, :item, :power, :created_at, :updated_at
+json.extract! @power_order, :id, :group_id, :item, :power, :item_url, :created_at, :updated_at

--- a/config/locales/01_model/ja.yml
+++ b/config/locales/01_model/ja.yml
@@ -62,6 +62,7 @@ ja:
           power: 電力[W]
           manufacturer: メーカ
           model: 型番
+          item_url: 使用機器の製品URL
         stage_order:
           group_name: 運営団体の名称
           stage_first: 場所(第一希望)

--- a/config/locales/03_views/ja.yml
+++ b/config/locales/03_views/ja.yml
@@ -20,7 +20,7 @@ ja:
       hint_power: 機器の電力を入力して下さい．1団体が使用可能な電力は全機器の合計で1000[W](ステージ団体:2500[W])です．
       hint_manufacturer: 機器の製造メーカを入力してください．例) YAMAZEN
       hint_model: 機器の型番を入力してください．例) HGB-1300
-      hint_item_url: 機器の電力が表記されているURLを入力してください．例）AmazonのURLなど．
+      hint_item_url: 機器の電力が表記されているURLを入力してください．例）AmazonのURLなど．なお, 分からない場合は「なし」と入力してください．
     show:
       confirm: この操作は取り消せません. 本当に削除しますか?
     index:

--- a/config/locales/03_views/ja.yml
+++ b/config/locales/03_views/ja.yml
@@ -20,6 +20,7 @@ ja:
       hint_power: 機器の電力を入力して下さい．1団体が使用可能な電力は全機器の合計で1000[W](ステージ団体:2500[W])です．
       hint_manufacturer: 機器の製造メーカを入力してください．例) YAMAZEN
       hint_model: 機器の型番を入力してください．例) HGB-1300
+      hint_item_url: 機器の電力が表記されているURLを入力してください．例）AmazonのURLなど．
     show:
       confirm: この操作は取り消せません. 本当に削除しますか?
     index:

--- a/db/migrate/20180515021230_add_column_power_orders.rb
+++ b/db/migrate/20180515021230_add_column_power_orders.rb
@@ -1,0 +1,5 @@
+class AddColumnPowerOrders < ActiveRecord::Migration
+  def change
+    add_column :power_orders, :item_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180505051949) do
+ActiveRecord::Schema.define(version: 20180515021230) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -215,6 +215,7 @@ ActiveRecord::Schema.define(version: 20180505051949) do
     t.datetime "updated_at",   null: false
     t.string   "manufacturer", null: false
     t.string   "model",        null: false
+    t.string   "item_url"
   end
 
   add_index "power_orders", ["group_id"], name: "index_power_orders_on_group_id", using: :btree


### PR DESCRIPTION
resolve #232 

やったこと
- PowerOrderにitem_url(使用機器の商品URL)カラムを追加
- Form, Viewにitem_urlを追加
- URLのバリデーション(正規表現)を設定
- ヒントを追加

必要な作業
- `bundle exec rake db:migrate`