### PR TITLE
従業員の役割を入力フォームに表示しない

### DIFF
--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -7,8 +7,8 @@ class Employee < ActiveRecord::Base
   # before_save :give_duplication
   # before_destroy :remove_duplication # レコードのdelete後に実行
 
-  validates_presence_of :group_id, :student_id, :name, :employee_category_id
-  validates_numericality_of :group_id, :student_id, :employee_category_id, only_integer: true
+  validates_presence_of :group_id, :student_id, :name
+  validates_numericality_of :group_id, :student_id, only_integer: true
 
   validates :student_id, format: { with: /(\A\d{8}+\z)/i }
 

--- a/app/views/employees/_form.html.erb
+++ b/app/views/employees/_form.html.erb
@@ -9,9 +9,6 @@
   <%= f.input :student_id, hint: t(".hint_studentid") %>
   <%= error_span(@employee[:student_id]) %>
 
-  <%= f.association :employee_category, hint: t(".hint_category") %>
-  <%= error_span(@employee[:employee_category_id]) %>
-
   <%= f.button :submit, :class => 'btn-primary' %>
   <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
                 employees_path, :class => 'btn btn-default' %>

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -8,7 +8,6 @@
       <th><%= model_class.human_attribute_name(:group) %></th>
       <th><%= model_class.human_attribute_name(:name) %></th>
       <th><%= model_class.human_attribute_name(:student_id) %></th>
-      <th><%= model_class.human_attribute_name(:employee_category) %></th>
       <th><%=t '.actions', :default => t("helpers.actions") %></th>
     </tr>
   </thead>
@@ -18,7 +17,6 @@
         <td><%= employee.group.name %></td>
         <td><%= employee.name %></td>
         <td><%= employee.student_id %></td>
-        <td><%= employee.employee_category %></td>
         <td>
           <%= show_edit_botton(edit_employee_path(employee), employee) %>
           <%= show_destroy_botton(employee_path(employee), employee) %>

--- a/app/views/employees/show.html.erb
+++ b/app/views/employees/show.html.erb
@@ -10,8 +10,6 @@
   <dd><%= @employee.name %></dd>
   <dt><strong><%= model_class.human_attribute_name(:student_id) %>:</strong></dt>
   <dd><%= @employee.student_id %></dd>
-  <dt><strong><%= model_class.human_attribute_name(:employee_category) %>:</strong></dt>
-  <dd><%= @employee.employee_category %></dd>
 </dl>
 
 <%= link_to t('.back', :default => t("helpers.links.back")),


### PR DESCRIPTION
#284 
従業員の役割に関係なく検便を集めることになったので役割分けは不要になった
モデルの変更は行わず、入力フォームで役割の選択を表示しないようにした
従業員名簿の出力の修正は別のプルリクで行う