### PR TITLE
フィルタを自動で生成しないように

### DIFF
--- a/app/admin/assign_group_place.rb
+++ b/app/admin/assign_group_place.rb
@@ -32,5 +32,6 @@ ActiveAdmin.register AssignGroupPlace do
   filter :fes_year
   filter :group_name, as: :string
   filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection([1,2,5,4,6])} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
+  filter :place, as: :select, collection: Place.usable_all_places
 
 end

--- a/app/admin/assign_stage.rb
+++ b/app/admin/assign_stage.rb
@@ -65,6 +65,17 @@ ActiveAdmin.register AssignStage do
   filter :fes_year
   filter :group_name, as: :string
   filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(3)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
+  filter :stage_order_is_sunny, as: :select, collection: {"晴天時": true, "雨天時": false}
+  filter :stage_order_fes_date_id, as: :select, collection: FesDate.where(fes_year_id: FesYear.this_year)
+  filter :stage_order_stage_first, as: :select, collection: Stage.all
+  filter :stage_order_stage_second, as: :select, collection: Stage.all
+  filter :stage_order_use_time_interval, :as => :select, :collection => StageOrder.use_time_intervals
+  filter :stage_order_prepare_time_interval, :as => :select, :collection => StageOrder.time_intervals
+  filter :stage_order_cleanup_time_interval, :as => :select, :collection => StageOrder.time_intervals
+  filter :stage_order_prepare_start_time, :as => :select, :collection => StageOrder.time_points
+  filter :stage_order_performance_start_time, :as => :select, :collection => StageOrder.time_points
+  filter :stage_order_performance_end_time, :as => :select, :collection => StageOrder.time_points
+  filter :stage_order_cleanup_end_time, :as => :select, :collection => StageOrder.time_points
 
 end
 

--- a/app/admin/place_allow_list.rb
+++ b/app/admin/place_allow_list.rb
@@ -30,4 +30,7 @@ ActiveAdmin.register PlaceAllowList do
     f.actions
   end
 
+  filter :place
+  filter :group_category
+
 end

--- a/app/admin/place_order.rb
+++ b/app/admin/place_order.rb
@@ -56,5 +56,8 @@ ActiveAdmin.register PlaceOrder do
   filter :fes_year
   filter :group_name, as: :string
   filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection([1,2,5,4,6])} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
+  filter :first, as: :select, collection: Place.usable_all_places
+  filter :second, as: :select, collection: Place.usable_all_places
+  filter :third, as: :select, collection: Place.usable_all_places
 
 end

--- a/app/admin/purchase_list.rb
+++ b/app/admin/purchase_list.rb
@@ -42,5 +42,10 @@ ActiveAdmin.register PurchaseList do
   filter :fes_year
   filter :group_name, as: :string
   filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(0)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
+  filter :food_product_name, as: :string
+  filter :food_product_is_cooking, as: :select, collection: {'調理あり': true, '調理なし(提供のみ)': false}
+  filter :shop
+  filter :items, as: :string
+  filter :is_fresh
 
 end

--- a/app/admin/rentable_item.rb
+++ b/app/admin/rentable_item.rb
@@ -24,4 +24,9 @@ ActiveAdmin.register RentableItem do
     column :max_num
     actions
   end
+
+  preserve_default_filters!
+  filter :stocker_item_rental_item_id, as: :select, collection: RentalItem.all
+  filter :stocker_item_stocker_place_id, as: :select, collection: StockerPlace.all
+  filter :stocker_place
 end

--- a/app/admin/rental_item_allow_list.rb
+++ b/app/admin/rental_item_allow_list.rb
@@ -12,22 +12,7 @@ ActiveAdmin.register RentalItemAllowList do
     actions
   end
 
-
-
-
-
-  # See permitted parameters documentation:
-  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-  #
-  # permit_params :list, :of, :attributes, :on, :model
-  #
-  # or
-  #
-  # permit_params do
-  #   permitted = [:permitted, :attributes]
-  #   permitted << :other if resource.something?
-  #   permitted
-  # end
-
+  filter :rental_item
+  filter :group_category
 
 end

--- a/app/admin/rental_order.rb
+++ b/app/admin/rental_order.rb
@@ -40,5 +40,6 @@ ActiveAdmin.register RentalOrder do
   filter :fes_year
   filter :group_name, as: :string
   filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(0)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
+  filter :rental_item
 
 end

--- a/app/admin/stage_order.rb
+++ b/app/admin/stage_order.rb
@@ -108,5 +108,16 @@ ActiveAdmin.register StageOrder do
   filter :fes_year
   filter :group_name, as: :string
   filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(3)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
+  filter :is_sunny, as: :select, collection: {"晴天時": true, "雨天時": false}
+  filter :fes_date, as: :select, collection: FesDate.where(fes_year_id: FesYear.this_year)
+  filter :stage_first, as: :select, collection: Stage.all
+  filter :stage_second, as: :select, collection: Stage.all
+  filter :use_time_interval, :as => :select, :collection => StageOrder.use_time_intervals
+  filter :prepare_time_interval, :as => :select, :collection => StageOrder.time_intervals
+  filter :cleanup_time_interval, :as => :select, :collection => StageOrder.time_intervals
+  filter :prepare_start_time, :as => :select, :collection => StageOrder.time_points
+  filter :performance_start_time, :as => :select, :collection => StageOrder.time_points
+  filter :performance_end_time, :as => :select, :collection => StageOrder.time_points
+  filter :cleanup_end_time, :as => :select, :collection => StageOrder.time_points
 
 end

--- a/app/admin/stage_order.rb
+++ b/app/admin/stage_order.rb
@@ -68,13 +68,13 @@ ActiveAdmin.register StageOrder do
       f.input :is_sunny
       f.input :stage_first, :as => :select, :collection => Stage.all
       f.input :stage_second, :as => :select, :collection => Stage.all
-      f.input :use_time_interval, :as => :select, :collection => @use_time_intervals
-      f.input :prepare_time_interval, :as => :select, :collection => @time_intervals
-      f.input :cleanup_time_interval, :as => :select, :collection => @time_intervals
-      f.input :prepare_start_time, :as => :select, :collection => @time_points
-      f.input :performance_start_time, :as => :select, :collection => @time_points
-      f.input :performance_end_time, :as => :select, :collection => @time_points
-      f.input :cleanup_end_time, :as => :select, :collection => @time_points
+      f.input :use_time_interval, :as => :select, :collection => StageOrder.use_time_intervals
+      f.input :prepare_time_interval, :as => :select, :collection => StageOrder.time_intervals
+      f.input :cleanup_time_interval, :as => :select, :collection => StageOrder.time_intervals
+      f.input :prepare_start_time, :as => :select, :collection => StageOrder.time_points
+      f.input :performance_start_time, :as => :select, :collection => StageOrder.time_points
+      f.input :performance_end_time, :as => :select, :collection => StageOrder.time_points
+      f.input :cleanup_end_time, :as => :select, :collection => StageOrder.time_points
     end
     f.actions
   end
@@ -109,24 +109,4 @@ ActiveAdmin.register StageOrder do
   filter :group_name, as: :string
   filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(3)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
 
-end
-
-def set_time_params
-  @time_points = [["", ""]]
-  (8..21).each do |h|
-    %w(00 15 30 45).each do |m|
-      @time_points.push ["#{"%02d" % h}:#{m}","#{"%02d" % h}:#{m}"]
-    end
-  end
-  @time_intervals = [["", ""],
-                    ["0分", "0分"],
-                    ["5分", "5分"],
-                    ["10分", "10分"],
-                    ["15分", "15分"],
-                    ["20分", "20分"]]
-  @use_time_intervals = [["", ""],
-                         ["30分", "30分"],
-                         ["1時間", "1時間"],
-                         ["1時間30分", "1時間30分"],
-                         ["2時間", "2時間"]]
 end

--- a/app/admin/stocker_item.rb
+++ b/app/admin/stocker_item.rb
@@ -1,19 +1,4 @@
 ActiveAdmin.register StockerItem do
-
-
-  # See permitted parameters documentation:
-  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-  #
-  # permit_params :list, :of, :attributes, :on, :model
-  #
-  # or
-  #
-  # permit_params do
-  #   permitted = [:permitted, :attributes]
-  #   permitted << :other if resource.something?
-  #   permitted
-  # end
-
   permit_params :rental_item_id, :stocker_place_id, :num, :fes_year_id
 
   index do
@@ -25,5 +10,10 @@ ActiveAdmin.register StockerItem do
     column :num
     actions
   end
+
+  preserve_default_filters!
+  filter :fes_year
+  filter :rental_item
+  filter :stocker_place
 
 end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -14,6 +14,7 @@ ActiveAdmin.register User do
   end
 
   filter :email
+  filter :role
   filter :current_sign_in_at
   filter :sign_in_count
   filter :created_at

--- a/app/controllers/stage_orders_controller.rb
+++ b/app/controllers/stage_orders_controller.rb
@@ -80,22 +80,8 @@ class StageOrdersController < GroupBase
 
     # 時刻入力の選択肢生成
     def set_time_params
-      @time_points = [["", ""]]
-      (8..21).each do |h|
-        %w(00 15 30 45).each do |m|
-          @time_points.push ["#{"%02d" % h}:#{m}","#{"%02d" % h}:#{m}"]
-        end
-      end
-      @time_intervals = [["", ""],
-                        ["0分", "0分"],
-                        ["5分", "5分"],
-                        ["10分", "10分"],
-                        ["15分", "15分"],
-                        ["20分", "20分"]]
-      @use_time_intervals = [["", ""],
-                             ["30分", "30分"],
-                             ["1時間", "1時間"],
-                             ["1時間30分", "1時間30分"],
-                             ["2時間", "2時間"]]
+      @time_points = StageOrder.time_points
+      @time_intervals = StageOrder.time_intervals
+      @use_time_intervals = StageOrder.use_time_intervals
     end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -4,4 +4,8 @@ class Role < ActiveRecord::Base
   validates :name,
     presence: true,  # 必須
     uniqueness: true # 重複不可
+
+  def to_s
+    self.name
+  end
 end

--- a/app/models/stage_order.rb
+++ b/app/models/stage_order.rb
@@ -136,4 +136,30 @@ class StageOrder < ActiveRecord::Base
     end
   end
 
+  def self.time_points
+    time_points = [["", ""]]
+    (8..21).each do |h|
+      %w(00 15 30 45).each do |m|
+        time_points.push ["#{"%02d" % h}:#{m}","#{"%02d" % h}:#{m}"]
+      end
+    end
+    time_points
+  end
+
+  def self.time_intervals
+    time_intervals = [["", ""],
+                     ["0分", "0分"],
+                     ["5分", "5分"],
+                     ["10分", "10分"],
+                     ["15分", "15分"],
+                     ["20分", "20分"]]
+  end
+
+  def self.use_time_intervals
+    use_time_intervals = [["", ""],
+                          ["30分", "30分"],
+                          ["1時間", "1時間"],
+                          ["1時間30分", "1時間30分"],
+                          ["2時間", "2時間"]]
+  end
 end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -248,5 +248,7 @@ ActiveAdmin.setup do |config|
   #
   # config.filters = true
 
+  # デフォルトでassociationが設定されたモデルをfilterに含めない
+  config.include_default_association_filters = false
 
 end

--- a/docs/issue276.md
+++ b/docs/issue276.md
@@ -1,0 +1,262 @@
+# issue276
+
+# デフォルトでassociationが設定されたモデルを自動でfilterに含めないようにする
+
+`config/initializers/active_admin.rb` で次の設定を行う
+
+```
+config.include_default_association_filters = false
+```
+
+associationが設定されたモデルを自動でfilterに含めてくれなくなるため，必要な部分は手動で設定する必要があります．
+
+# filterに含めたい項目
+
+各モデルのassociationを参考にfilterの項目を決定します．
+検索機能を使わないと思われるもの，デフォルトおよび現在の設定で不足ないものは除外します．
+
+### Group
+
+- デフォルトである
+    * 運営団体の名称
+    * 主な活動内容
+- 設定しないといけない
+    * 年度
+    * 参加形式
+
+### User
+
+- デフォルトである
+    * email
+- 設定しないといけない
+    * role_id
+
+### StageOrder
+
+デフォルトのフィルターの場所・時間がID指定なので，セレクトボックスにする
+
+- デフォルトである
+    * 天候
+    * 場所
+    * 時間
+- 設定しないといけない
+    * 年度
+    * 運営団体の名称
+    * 運営団体のセレクトボックス
+    * 場所セレクトボックス
+    * 開催日
+
+### AssignStage
+
+- 設定しないといけない
+    * 天候
+    * 場所
+    * 時間
+    * 年度
+    * 運営団体の名称
+    * 運営団体のセレクトボックス
+    * 開催日
+
+### PlaceOrder
+
+デフォルトのフィルターの場所がID指定なので，セレクトボックスにする
+
+- デフォルトである
+    * 場所
+    * 備考
+- 設定しないといけない
+    * 年度
+    * 運営団体の名称
+    * 運営団体のセレクトボックス
+    * 場所名セレクトボックス
+
+### PlaceAllowList
+
+- 設定しないといけない
+    * 場所名セレクトボックス
+    * 団体カテゴリ名セレクトボックス
+
+### AssignGroupPlace
+
+- 設定しないといけない
+    * 年度
+    * 運営団体の名称
+    * 運営団体のセレクトボックス
+    * 場所
+
+### RentalOrder
+
+- デフォルトである
+    * 数量
+- 設定しないといけない
+    * 年度
+    * 運営団体の名称
+    * 運営団体のセレクトボックス
+    * 物品名セレクトボックス
+
+### RentableItem
+
+- デフォルトである
+    * 貸出可能数
+- 設定しないといけない
+    * 物品名
+    * 貸出場所
+    * 保管場所
+
+### RentalItemAllowList
+
+- 設定しないといけない
+    * 物品名セレクトボックス
+    * 団体カテゴリ名セレクトボックス
+
+### StockerItem
+
+- デフォルトである
+    * 数量
+- 設定しないといけない
+    * 年度
+    * 物品名セレクトボックス
+    * 保管場所
+
+### PurchaseList
+
+- デフォルトである
+    * 購入品のリスト
+- 設定しないといけない
+    * 年度
+    * 運営団体の名称
+    * 運営団体のセレクトボックス
+    * 販売食品
+    * 調理あり・なし
+    * 仕入先
+    * 仕入品名
+
+
+# ActiveAdminでメソッド参照がうまくいかない
+
+`app/admin/stage_order.rb` で定義された `set_time_params` メソッドをフィルタ定義の前で呼び出しても `no method error` が出た． `before_filter` の中で呼び出したり試してみたが，うまくいかなかった．controllerでも同じコードが記述されているので，せっかくだからmodelで各プロパティを返すメソッドを定義することにした．
+
+各時間を返すメソッドを `app/models/stage_order.rb` に定義
+
+```diff
++  def self.time_points
++    time_points = [["", ""]]
++    (8..21).each do |h|
++      %w(00 15 30 45).each do |m|
++        time_points.push ["#{"%02d" % h}:#{m}","#{"%02d" % h}:#{m}"]
++      end
++    end
++    time_points
++  end
++
++  def self.time_intervals
++    time_intervals = [["", ""],
++                     ["0分", "0分"],
++                     ["5分", "5分"],
++                     ["10分", "10分"],
++                     ["15分", "15分"],
++                     ["20分", "20分"]]
++  end
++
++  def self.use_time_intervals
++    use_time_intervals = [["", ""],
++                          ["30分", "30分"],
++                          ["1時間", "1時間"],
++                          ["1時間30分", "1時間30分"],
++                          ["2時間", "2時間"]]
++  end
+ end
+```
+
+定義したメソッドを使うようにする
+
+`app/admin/stage_order.rb`
+
+```diff
+       f.input :is_sunny
+       f.input :stage_first, :as => :select, :collection => Stage.all
+       f.input :stage_second, :as => :select, :collection => Stage.all
+-      f.input :use_time_interval, :as => :select, :collection => @use_time_intervals
+-      f.input :prepare_time_interval, :as => :select, :collection => @time_intervals
+-      f.input :cleanup_time_interval, :as => :select, :collection => @time_intervals
+-      f.input :prepare_start_time, :as => :select, :collection => @time_points
+-      f.input :performance_start_time, :as => :select, :collection => @time_points
+-      f.input :performance_end_time, :as => :select, :collection => @time_points
+-      f.input :cleanup_end_time, :as => :select, :collection => @time_points
++      f.input :use_time_interval, :as => :select, :collection => StageOrder.use_time_intervals
++      f.input :prepare_time_interval, :as => :select, :collection => StageOrder.time_intervals
++      f.input :cleanup_time_interval, :as => :select, :collection => StageOrder.time_intervals
++      f.input :prepare_start_time, :as => :select, :collection => StageOrder.time_points
++      f.input :performance_start_time, :as => :select, :collection => StageOrder.time_points
++      f.input :performance_end_time, :as => :select, :collection => StageOrder.time_points
++      f.input :cleanup_end_time, :as => :select, :collection => StageOrder.time_points
+     end
+     f.actions
+   end
+@@ -108,25 +108,16 @@ ActiveAdmin.register StageOrder do
+   filter :fes_year
+   filter :group_name, as: :string
+   filter :group, label: "運営団体", as: :select, collection: proc {Group.active_admin_collection(3)} # 見やすくなるようにGroupを年度順にセパレータ付きで表示
+
+ 
+ end
+-
+-def set_time_params
+-  @time_points = [["", ""]]
+-  (8..21).each do |h|
+-    %w(00 15 30 45).each do |m|
+-      @time_points.push ["#{"%02d" % h}:#{m}","#{"%02d" % h}:#{m}"]
+-    end
+-  end
+-  @time_intervals = [["", ""],
+-                    ["0分", "0分"],
+-                    ["5分", "5分"],
+-                    ["10分", "10分"],
+-                    ["15分", "15分"],
+-                    ["20分", "20分"]]
+-  @use_time_intervals = [["", ""],
+-                         ["30分", "30分"],
+-                         ["1時間", "1時間"],
+-                         ["1時間30分", "1時間30分"],
+-                         ["2時間", "2時間"]]
+-end
+```
+
+`app/controllers/stage_orders_controller.rb`
+
+```diff
+
+ 
+     # 時刻入力の選択肢生成
+     def set_time_params
+-      @time_points = [["", ""]]
+-      (8..21).each do |h|
+-        %w(00 15 30 45).each do |m|
+-          @time_points.push ["#{"%02d" % h}:#{m}","#{"%02d" % h}:#{m}"]
+-        end
+-      end
+-      @time_intervals = [["", ""],
+-                        ["0分", "0分"],
+-                        ["5分", "5分"],
+-                        ["10分", "10分"],
+-                        ["15分", "15分"],
+-                        ["20分", "20分"]]
+-      @use_time_intervals = [["", ""],
+-                             ["30分", "30分"],
+-                             ["1時間", "1時間"],
+-                             ["1時間30分", "1時間30分"],
+-                             ["2時間", "2時間"]]
++      @time_points = StageOrder.time_points
++      @time_intervals = StageOrder.time_intervals
++      @use_time_intervals = StageOrder.use_time_intervals
+     end
+ end
+diff --git a/app/models/stage_order.rb b/app/models/stage_order.rb
+index e4791b1..956d34e 100644
+--- a/app/models/stage_order.rb
++++ b/app/models/stage_order.rb
+@@ -136,4 +136,30 @@ class StageOrder < ActiveRecord::Base
+     end
+   end
+
+```


### PR DESCRIPTION
resolve #276 

# 内容

- デフォルトでフィルタを自動生成しないように設定ファイルを変更
- 自動で生成されなくなったので，必要なフィルタを追加
- idを選択させるような使い難いフィルタを修正