### PR TITLE
代表と副代表の電話番号が同じ時エラー

### DIFF
--- a/app/models/sub_rep.rb
+++ b/app/models/sub_rep.rb
@@ -15,4 +15,13 @@ class SubRep < ActiveRecord::Base
   validates :tel, format: { with: /(\A\d{3}-\d{4}-\d{4}+\z)|(\A\d{4}-\d{2}-\d{4})+\z/i }
 
   validates :email, :email_format => { :message => '有効なe-mailアドレスを入力してください' }
+
+  # 電話番号が代表者と同じ場合登録することができなくする
+  validate :valid_tel  
+
+  def valid_tel
+    if tel == group.user.user_detail.tel
+      errors.add(:tel,"代表者と副代表者は別にしてください")
+    end
+  end
 end


### PR DESCRIPTION
副代表者の登録時に代表者と同じ電話番号が登録された時にエラーが出るようにした．

<変更点>
sub_rep.rbにカスタムバリデーションを追加
