### PR TITLE
pumaの設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,3 +94,8 @@ gem 'listen'
 gem 'rails-i18n'
 
 gem 'wkhtmltopdf-binary'
+
+# puma
+gem 'puma'
+gem 'puma_worker_killer'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.6.0)
+    get_process_mem (0.2.3)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     has_scope (0.7.2)
@@ -171,6 +172,10 @@ GEM
     pry-stack_explorer (0.4.9.3)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
+    puma (3.12.1)
+    puma_worker_killer (0.1.0)
+      get_process_mem (~> 0.2)
+      puma (>= 2.7, < 4)
     rack (2.0.6)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -311,6 +316,8 @@ DEPENDENCIES
   pry-doc
   pry-rails
   pry-stack_explorer
+  puma
+  puma_worker_killer
   rails (~> 5.2.0)
   rails-i18n
   rails_12factor

--- a/config/puma/production.rb
+++ b/config/puma/production.rb
@@ -1,0 +1,41 @@
+# config/puma/production.rb
+environment "production"
+
+# UNIX Socketへのバインド
+tmp_path = "#{File.expand_path("../../..", __FILE__)}/tmp"
+bind "unix://#{tmp_path}/sockets/puma.sock"
+
+# スレッド数とWorker数の指定
+threads 3, 3
+workers 2
+preload_app!
+
+# デーモン化の設定
+daemonize true
+pidfile "#{tmp_path}/pids/puma.pid"
+stdout_redirect "#{tmp_path}/logs/puma.stdout.log", "#{tmp_path}/logs/puma.stderr.log", true
+
+# Allow puma to be restarted by `rails restart` command.
+plugin :tmp_restart
+
+# puma_worker_killerの設定
+before_fork do
+  require 'puma_worker_killer'
+  PumaWorkerKiller.config do |config|
+    # 閾値を超えた場合にkillする
+    config.ram           = 1024 # mb
+    config.frequency     = 5 * 60 # per 5minute
+    config.percent_usage = 0.9 # 90%
+    # 閾値を超えたかどうかに関わらず定期的にkillする
+    config.rolling_restart_frequency = 24 * 3600 # per 1day
+    # workerをkillしたことをログに残す
+    config.reaper_status_logs = true
+  end
+  PumaWorkerKiller.start
+  ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
+end
+
+on_worker_boot do
+  ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+end
+


### PR DESCRIPTION
https://github.com/NUTFes/group-manager/pull/330 でcapistrano+pumaの設定を行なっていたが，capistranoがうまく動作しなかったため，先にpumaの設定を行なった

以下に，現状のVPSでの動作環境をまとめる
- ユーザ: root
- directory: `/var/www/group-manager`
- puma起動コマンド: `bin/rails s -e production`
- pumaが起動しているかの確認: `ps aux|grep puma`
- pumaの停止: `bundle exec pumactl -P tmp/pids/puma.pid halt`
- pumaの再起動: `bundle exec pumactl -P tmp/pids/puma.pid restart`
- nginxの設定ファイル: `/etc/nginx/sites-available/group-manager.nutfes.net`
- 公開URI: https://group-manager.nutfes.net

デプロイの仕方
- VPSにrootでログイン
- `cd /var/www/group-manager`
- `git pull --rebase`
- `bin/rake db:create RAILS_ENV=production`
- `bin/rake db:migrate RAILS_ENV=production`
- `bin/rake db:seed_fu RAILS_ENV=production`
- `bundle exec pumactl -P tmp/pids/puma.pid restart`