### PR TITLE
管理画面をわかりやすくする

### DIFF
--- a/app/admin/fes_date.rb
+++ b/app/admin/fes_date.rb
@@ -20,6 +20,7 @@ ActiveAdmin.register FesDate do
     selectable_column
     id_column
     column :fes_year
+    column :date
     column :day
     column :days_num
     actions

--- a/config/locales/01_model/ja.yml
+++ b/config/locales/01_model/ja.yml
@@ -1,38 +1,38 @@
 ja:
   activerecord:
     models:
-      group: 参加団体
-      user_detail: ユーザ情報
-      rental_item: 貸出物品
-      rental_order: 物品貸出の申請
-      rental_item_allow_list: 団体カテゴリ利用可能物品
-      power_order: 使用電力の申請
-      stage_order: ステージ利用の申請
-      place_order: 実施場所の申請
-      place_allow_list: 場所の利用許可
-      employee: 従業員
-      food_product: 販売食品
-      purchase_list: 購入リスト
-      shop: 仕入先
-      sub_rep: 副代表
-      stage_common_option: ステージ利用の詳細
-      stocker_item: 貸出物品の在庫
-      rentable_item: 貸出可能物品
-      config_user_permission: 募集状態の制御
-      group_project_name: 企画名
-      stage: ステージ
-      group_manager_common_option: アプリ共通設定
-      assign_stage: 使用ステージ
-      assign_group_place: 使用場所
-      assign_rental_item: 貸出物品の割当
-      comment: コメント
-      fes_date: 開催日
-      fes_year: 開催年
-      group_category: 参加団体カテゴリー
-      place: 場所
-      role: 権限
-      stocker_place: 保管場所
-      user: ユーザ
+      group: 02.参加団体
+      user_detail: 01.ユーザ情報
+      rental_item: 06.貸出物品
+      rental_order: 07.物品貸出の申請
+      rental_item_allow_list: (団体カテゴリ利用可能物品)
+      power_order: 10.使用電力の申請
+      stage_order: 14.ステージ利用の申請
+      place_order: 12.実施場所の申請
+      place_allow_list: 11.場所の利用許可
+      employee: 17.従業員
+      food_product: 18.販売食品
+      purchase_list: 19.購入リスト
+      shop: 20.仕入先
+      sub_rep: 04.副代表
+      stage_common_option: 15.ステージ利用の詳細
+      stocker_item: 08.貸出物品の在庫
+      rentable_item: 05.貸出可能物品
+      config_user_permission: 21.募集状態の制御
+      group_project_name: 03.企画名
+      stage: (ステージ)
+      group_manager_common_option: (アプリ共通設定)
+      assign_stage: 16.使用ステージ
+      assign_group_place: 13.使用場所
+      assign_rental_item: 09.貸出物品の割当
+      comment: (コメント)
+      fes_date: (開催日)
+      fes_year: (開催年)
+      group_category: (参加団体カテゴリー)
+      place: (場所)
+      role: (権限)
+      stocker_place: (保管場所)
+      user: (ユーザ)
     attributes:
         group:
           name: 運営団体の名称


### PR DESCRIPTION
resoleve #303 

## やったこと
### 管理画面の"開催日"に日付のカラムがなかったので追加
`app/admin/fes_date.rb`を編集
### 管理画面のインデックスに番号を振った
- 非管理者画面の登録の順番と同じにした
- 総務局がいじらなくていいインデックスは()をつけて表示
いずれも`config/locales/01_model/ja.yml`を編集
日本語名の前に数字をつけただけ
"ユーザ"と"ユーザ情報"がわかりにくいという意見だったが，ユーザは(ユーザ)にして，ユーザ情報は01.ユーザ情報とした．カッコがついているものは総務局がいじらなくても良いことを周知すれば間違えないと思った．