### PR TITLE
テスト環境設定の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /tmp/pids/*
 /tmp/logs/*
 /tmp/sockets/*
+/tmp/restart.txt
 !/tmp/pids/.keep
 !/tmp/logs/.keep
 !/tmp/sockets/.keep

--- a/config/database.yml
+++ b/config/database.yml
@@ -58,6 +58,8 @@ development:
 test:
   <<: *default
   database: group_manager_test
+  username: group_manager
+  password: <%= ENV['GROUP_MANAGER_DATABASE_PASSWORD'] %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,46 +1,114 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # The test environment is used exclusively to run your application's
-  # test suite. You never need to work with it otherwise. Remember that
-  # your test database is "scratch space" for the test suite and is wiped
-  # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  # Code is not reloaded between requests.
+  config.cache_classes = false
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
   config.eager_load = false
 
-  # Configure public file server for tests with Cache-Control for performance.
-  config.public_file_server.enabled = true
-  config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
-  }
-
-  # Show full error reports and disable caching.
+  # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
+  # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
+  # config.require_master_key = true
 
-  # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
-  # Store uploaded files on the local file system in a temporary directory
-  config.active_storage.service = :test
+  # Compress JavaScripts and CSS.
+  config.assets.js_compressor = :uglifier
+  # config.assets.css_compressor = :sass
+
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
+  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :debug
+
+  #Prepend all log lines with the following tags.
+  config.log_tags = [ :request_id ]
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Use a real queuing backend for Active Job (and separate queues per environment)
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "group_manager_#{Rails.env}"
 
   config.action_mailer.perform_caching = false
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
 
-  # Print deprecation notices to the stderr.
-  config.active_support.deprecation = :stderr
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
 
-  # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :log
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  # Use a different logger for distributed setups.
+  # require 'syslog/logger'
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
+
+  # ---------------------------
+  # ActionMailer Config
+  # for device, e-mail
+  # ---------------------------
+  # sample settings
+  # https://github.com/RailsApps/rails-devise/blob/master/config/environments/development.rb
+  # `Rails.application.secrets.[domain_name, email_username, email_password]`は
+  # `config/secrets.yml`で定義される (このとき環境変数を読み込むべき)
+  config.action_mailer.smtp_settings = {
+    address: Rails.application.secrets.smtp_adress,
+    port: Rails.application.secrets.smtp_port,
+    domain: Rails.application.secrets.domain_name,
+    authentication: Rails.application.secrets.smtp_auth,
+    tls: Rails.application.secrets.smtp_tls,
+    enable_starttls_auto: true,
+    user_name: Rails.application.secrets.email_username,
+    password: Rails.application.secrets.email_password
+  }
+  config.action_mailer.default_url_options = { :host => Rails.application.secrets.default_url }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_options = {
+    bcc: Rails.application.secrets.email_bcc
+  }
+  config.action_mailer.raise_delivery_errors = true
+  # Send email in development mode?
+  config.action_mailer.perform_deliveries = true
+
+  config.web_console.development_only = false
+
 end
+

--- a/config/puma/test.rb
+++ b/config/puma/test.rb
@@ -1,0 +1,41 @@
+# config/puma/production.rb
+environment "test"
+
+# UNIX Socketへのバインド
+tmp_path = "#{File.expand_path("../../..", __FILE__)}/tmp"
+bind "unix://#{tmp_path}/sockets/group-manager-test-puma.sock"
+
+# スレッド数とWorker数の指定
+threads 3, 3
+workers 2
+preload_app!
+
+# デーモン化の設定
+daemonize true
+pidfile "#{tmp_path}/pids/group-manager-test-puma.pid"
+stdout_redirect "#{tmp_path}/logs/group-manager-test-puma.stdout.log", "#{tmp_path}/logs/group-manager-test-puma.stderr.log", true
+
+# Allow puma to be restarted by `rails restart` command.
+plugin :tmp_restart
+
+# puma_worker_killerの設定
+before_fork do
+  require 'puma_worker_killer'
+  PumaWorkerKiller.config do |config|
+    # 閾値を超えた場合にkillする
+    config.ram           = 1024 # mb
+    config.frequency     = 5 * 60 # per 5minute
+    config.percent_usage = 0.9 # 90%
+    # 閾値を超えたかどうかに関わらず定期的にkillする
+    config.rolling_restart_frequency = 24 * 3600 # per 1day
+    # workerをkillしたことをログに残す
+    config.reaper_status_logs = true
+  end
+  PumaWorkerKiller.start
+  ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
+end
+
+on_worker_boot do
+  ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+end
+

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -22,7 +22,17 @@ development:
   smtp_tls: <%= ENV["SMTP_TLS"] %>
 
 test:
-  secret_key_base: e6bac901670a9dbfcb0536bce47aedf1be30f2634ca891599d19430bf81f78036642101e490d9e00da7d5db609351ec73465b53f6bff4e7cfce319b9249363e9
+  secret_key_base: 8fa591881226e069a53fb6a7cd52a3e791da0a059900c00c0d7b5dedd68043a9d5f83ef4d4657ae6a763f5062ba389480dee4ea4f410a7015828a0059f26db95
+  # for e-mail
+  smtp_adress: <%= ENV["SMTP_ADRESS"] %>
+  smtp_port: <%= ENV["SMTP_PORT"] %>
+  domain_name: <%= ENV["EMAIL_DOMAIN"] %>
+  smtp_auth: <%= ENV["SMTP_AUTH"] %>
+  email_username: <%= ENV["EMAIL_USERNAME"] %>
+  email_password: <%= ENV["EMAIL_PASSWORD"] %>
+  email_bcc: <%= ENV["EMAIL_BCC"] %>
+  smtp_tls: <%= ENV["SMTP_TLS"] %>
+  default_url: <%= ENV["TEST_DEFAULT_URL"] %>
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/db/fixtures/test/0_user.rb
+++ b/db/fixtures/test/0_user.rb
@@ -1,0 +1,15 @@
+users = [{
+     :email=>"admin@nutfes.com",
+     :role=>Role.find(1),
+     :password=>"nutfes",
+     :password_confirmation=>"nutfes"
+ }
+]
+
+users.each do |u|
+    if User.where(:email => u[:email]).empty?
+        user = User.new(u)
+        user.skip_confirmation!
+        user.save(:validate=>false)
+    end
+end

--- a/db/fixtures/test/1_user_detail.rb
+++ b/db/fixtures/test/1_user_detail.rb
@@ -1,0 +1,9 @@
+UserDetail.seed( :id,
+{   id: 1,
+    user_id: User.where(:email => 'admin@nutfes.com').first.id,
+    name_en: "Taro Gidai (admin)",
+    name_ja: "技大太郎 (admin)",
+    department_id: 1,
+    grade_id: 1,
+    tel: "111-1111-1111",
+})

--- a/db/fixtures/test/2_group.rb
+++ b/db/fixtures/test/2_group.rb
@@ -1,0 +1,8 @@
+Group.seed(:id, {
+  id: 1,
+  name: "テストグループ(模擬店・食販)",
+  group_category_id: 1,
+  user_id: User.where(:email => 'admin@nutfes.com').first.id,
+  activity: "テストグループ(模擬店・食販)",
+  fes_year_id: FesYear.this_year.id,
+})

--- a/db/fixtures/test/3_sub_rep.rb
+++ b/db/fixtures/test/3_sub_rep.rb
@@ -1,0 +1,10 @@
+SubRep.seed( :id,
+{   id: 1,
+    group_id: 1,
+    name_en: "Taro Gidai (admin)",
+    name_ja: "技大太郎 (admin)",
+    email: "subrep@nutfes.com",
+    department_id: 2,
+    grade_id: 2,
+    tel: "111-0000-9999",
+})


### PR DESCRIPTION
productionに反映させる前の動作確認用にtest環境を構築する．
環境変数として`export TEST_DEFAULT_URL="<url_for_test>"`を設定する必要あり．

テスト環境の起動
- `sudo su`
- `cd /var/www/group-manager-test`
- `bin/rails s -e test`
- `ps aux|grep puma` (group-manager-testが起動していることを確認)

テスト環境の停止
- `sudo su`
- `cd /var/www/group-manager-test`
- `bundle exec pumactl -P tmp/pids/group-manager-test-puma.pid halt`
- `ps aux|grep puma` (group-manager-testが停止していることを確認)
