### PR TITLE
csv出力するカラムからcreated_at, updated_atを除いてエラー回避

### DIFF
--- a/app/admin/assign_group_place.rb
+++ b/app/admin/assign_group_place.rb
@@ -10,6 +10,12 @@ ActiveAdmin.register AssignGroupPlace do
     actions
   end
 
+  csv do
+    column :id
+    column :place_order
+    column :place
+  end
+
   form do |f|
     order  = f.object.place_order
     places = Place.usable_all_places

--- a/app/admin/assign_rental_item.rb
+++ b/app/admin/assign_rental_item.rb
@@ -23,6 +23,13 @@ ActiveAdmin.register AssignRentalItem do
     actions
   end
 
+  csv do
+    column :id
+    column :rental_order
+    column :rentable_item
+    column :num
+  end
+
   preserve_default_filters!
   filter :fes_year
   filter :group_name, as: :string

--- a/app/admin/assign_stage.rb
+++ b/app/admin/assign_stage.rb
@@ -34,6 +34,31 @@ ActiveAdmin.register AssignStage do
     actions
   end
 
+  csv do
+    column :id
+    column :stage_order do |as|
+      as.stage_order.group
+    end
+    column :fes_date do |as|
+      FesDate.find(as.stage_order.fes_date_id)
+    end
+    column :is_sunny do |as|
+      as.stage_order.is_sunny ? "晴天時" : "雨天時"
+    end
+    column :order_time_start do |as|
+      as.stage_order.prepare_start_time
+    end
+    column :order_time_end do |as|
+      as.stage_order.cleanup_end_time
+    end
+    column :order_time_interval do |as|
+      as.stage_order.use_time_interval
+    end
+    column :stage
+    column :time_point_start
+    column :time_point_end
+  end
+
   form do |f|
     set_time_point
     order  = f.object.stage_order

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -28,12 +28,13 @@ ActiveAdmin.register Group do
       group.user.user_detail.name_en
     end
     column :name
+    column :project_name do |group|
+      group.group_project_name.try(:project_name)
+    end
     column :group_category do |group|
       group.group_category.name_ja
     end
     column :activity
-    column :created_at
-    column :updated_at
   end
 
   show do

--- a/app/admin/group_project_name.rb
+++ b/app/admin/group_project_name.rb
@@ -10,6 +10,12 @@ ActiveAdmin.register GroupProjectName do
     actions
   end
 
+  csv do
+    column :id
+    column :group
+    column :project_name
+  end
+
   form do |f|
     year_id = FesYear.where(fes_year: Time.now.year).first.id
 

--- a/app/admin/place_allow_list.rb
+++ b/app/admin/place_allow_list.rb
@@ -19,6 +19,15 @@ ActiveAdmin.register PlaceAllowList do
     actions
   end
 
+  csv do
+    column :id
+    column :group_category_id do |order|
+      order.group_category
+    end
+    column :place
+    column :enable
+  end
+
   form do |f|
     inputs '場所を許可/不許可' do
       if current_user.role_id==1 then

--- a/app/admin/rentable_item.rb
+++ b/app/admin/rentable_item.rb
@@ -25,6 +25,13 @@ ActiveAdmin.register RentableItem do
     actions
   end
 
+  csv do
+    column :id
+    column :stocker_item
+    column :stocker_place
+    column :max_num
+  end
+
   preserve_default_filters!
   filter :stocker_item_rental_item_id, as: :select, collection: RentalItem.all
   filter :stocker_item_stocker_place_id, as: :select, collection: StockerPlace.all

--- a/app/admin/rental_item.rb
+++ b/app/admin/rental_item.rb
@@ -1,3 +1,10 @@
 ActiveAdmin.register RentalItem do
   permit_params :name_ja, :name_en, :is_rentable
+
+  csv do
+    column :id
+    column :name_ja
+    column :name_en
+    column :is_rentable
+  end
 end

--- a/app/admin/shop.rb
+++ b/app/admin/shop.rb
@@ -2,4 +2,22 @@ ActiveAdmin.register Shop do
 
   permit_params :name, :tel, :time_weekdays, :time_sat, :time_sun, :time_holidays,:is_closed_sun, :is_closed_mon, :is_closed_tue, :is_closed_wed, :is_closed_thu, :is_closed_fri, :is_closed_sat, :is_closed_holiday, :kana
 
+  csv do
+    column :id
+    column :name
+    column :kana
+    column :tel
+    column :time_weekdays
+    column :time_sat
+    column :time_sun
+    column :time_holidays
+    column :is_closed_sun
+    column :is_closed_mon
+    column :is_closed_tue
+    column :is_closed_wed
+    column :is_closed_thu
+    column :is_closed_fri
+    column :is_closed_sat
+    column :is_closed_holiday
+  end
 end

--- a/app/admin/stage.rb
+++ b/app/admin/stage.rb
@@ -2,14 +2,12 @@ ActiveAdmin.register Stage do
 
   permit_params :name_ja, :name_en, :enable_sunny, :enable_rainy
   
-    index do
+  index do
     id_column
-
     column :name_ja
     column :name_en
     column :enable_sunny
     column :enable_rainy
-
     actions
   end
 end

--- a/app/admin/stocker_item.rb
+++ b/app/admin/stocker_item.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register StockerItem do
-  permit_params :rental_item_id, :stocker_place_id, :num, :fes_year_id
+  permit_params :rental_item_id, :stocker_place_id, :num
 
   index do
     selectable_column
@@ -8,6 +8,14 @@ ActiveAdmin.register StockerItem do
     column :rental_item
     column :num
     actions
+  end
+
+  csv do
+    column :id
+    column :stocker_place
+    column :rental_item
+    column :num
+
   end
 
   preserve_default_filters!

--- a/app/admin/sub_rep.rb
+++ b/app/admin/sub_rep.rb
@@ -27,6 +27,17 @@ ActiveAdmin.register SubRep do
     actions
   end
 
+  csv do
+    column :id
+    column :group
+    column :name_ja
+    column :name_en
+    column :department
+    column :grade
+    column :tel
+    column :email
+  end
+
   preserve_default_filters!
   filter :fes_year
   filter :group_name, as: :string

--- a/app/admin/user_detail.rb
+++ b/app/admin/user_detail.rb
@@ -18,6 +18,19 @@ ActiveAdmin.register UserDetail do
     actions
   end
 
+  csv do
+    column :id
+    column :user
+    column :name_ja
+    column :name_en
+    column :grade
+    column :department
+    column :group do |detail|
+      detail.user.groups.pluck(:name).join(" , ")
+    end
+    column :tel
+  end
+
   form do |f|
     f.inputs "User Details" do
       f.input :user

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -1,2 +1,5 @@
 class Grade < ActiveRecord::Base
+  def to_s
+    self.name
+  end
 end


### PR DESCRIPTION
resolve #349 

やったこと
- csv出力するカラムにcreated_at, updated_atが含まれないようにするため，それ以外のカラムをcsv出力するように修正
- 修正したモデルは
  - 参加団体 (group)
  - 企画名 (group_project_name)
  - 副代表 (sub_rep)
  - 貸出物品 (rental_item)
  - 貸出物品の在庫 (stocker_item)
  - 貸出物品の割当 (assign_rental_item)
  - 場所の利用許可 (place_allow_list)
  - 使用場所 (assign_group_place)
  - 使用ステージ (assign_stage)
  - 仕入先 (shop)