### PR TITLE
貸出物品表のテンプレートをダウンロードできるように

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -52,6 +52,7 @@ ActiveAdmin.register_page "Dashboard" do
         panel "物品貸出書類" do
           li link_to("物品貸出票", rental_item_pages_for_pasting_room_sheet_path(format: 'pdf'))
           li link_to("物品持出し表（各団体向け）", group_information_pages_group_information_sheet_path(format: 'pdf'))
+          li link_to('[ダウンロード] 貸出物品表テンプレート', download_rental_item_list_admin_groups_path(format: 'csv'))
         end
       end
     end

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -119,7 +119,7 @@ ActiveAdmin.register Group do
 
   # 参加団体と物品がマトリックスのcsvを作る
   collection_action :download_rental_item_list, :method => :get do
-    groups = Group.where({ fes_year_id: FesYear.this_year})
+    groups = Group.where(fes_year_id: FesYear.this_year)
     groups = groups.sort{|g1, g2| g1.group_category_id <=> g2.group_category_id}  # category_id順にソート
     rental_item_allow_list_ids = RentalItemAllowList.pluck(:rental_item_id).uniq
     # RentaiItemの内，is_rentable=trueかつRentalItemAllowListに存在する物品の名前を取得する
@@ -131,9 +131,17 @@ ActiveAdmin.register Group do
       groups.each_with_index do |group, i|
         group_name = group.name
         group_category_name = group.group_category.name_ja
-        place_order = PlaceOrder.where(group_id: group.id).first
-        assign_place_name = place_order ? AssignGroupPlace.where(place_order_id: place_order.id).first.place.name_ja : ''
-        csv << [i+1, group_category_name, group_name, assign_place_name]
+        if group.group_category_id == 3  # ステージ団体の場合
+          stage_order = StageOrder.where(group_id: group.id).first  # 1日目晴の申請
+          assign_stage = stage_order ? AssignStage.where(stage_order_id: stage_order.id).first : nil
+          assign_stage_name = assign_stage ? assign_stage.stage.name_ja + '(1日目晴)' : ''
+          csv << [i+1, group_category_name, group_name, assign_stage_name]
+        else
+          place_order = PlaceOrder.where(group_id: group.id).first
+          assign_place = place_order ? AssignGroupPlace.where(place_order_id: place_order.id).first : nil
+          assign_place_name = assign_place ? assign_place.place.name_ja : ''
+          csv << [i+1, group_category_name, group_name, assign_place_name]
+        end
       end
 
     end

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -143,7 +143,8 @@ ActiveAdmin.register Group do
           elsif assign_stage_first and assign_stage_first.stage.id == 0
             stage_order_second = StageOrder.where(group_id: group.id).third  # 2日目晴の申請
             assign_stage_second = stage_order_second ? AssignStage.where(stage_order_id: stage_order_second.id).first : nil
-            assign_stage_name = assign_stage_second.stage.name_ja + '(2日目晴)'
+            assign_stage_name = assign_stage_second ? assign_stage_second.stage.name_ja : ''
+            assign_stage_name += '(2日目晴)' if assign_stage_second.stage.id != 0  # 未入力の場合は(2日目晴)をつけない
           else
             assign_stage_name = ''
           end

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -120,8 +120,10 @@ ActiveAdmin.register Group do
   # 参加団体と物品がマトリックスのcsvを作る
   collection_action :download_rental_item_list, :method => :get do
     groups = Group.where({ fes_year_id: FesYear.this_year})
-    groups = groups.sort{|g1, g2| g1.group_category_id <=> g2.group_category_id}
-    rental_item_names = RentalItem.where(is_rentable: true).map{ |item| item.name_ja }
+    groups = groups.sort{|g1, g2| g1.group_category_id <=> g2.group_category_id}  # category_id順にソート
+    rental_item_allow_list_ids = RentalItemAllowList.pluck(:rental_item_id).uniq
+    # RentaiItemの内，is_rentable=trueかつRentalItemAllowListに存在する物品の名前を取得する
+    rental_item_names = RentalItem.where(is_rentable: true).where(id: rental_item_allow_list_ids).pluck(:name_ja)
     value_columns = rental_item_names.map{ |_| '数量' }  # 物品数と同じだけ数量カラムを作る
     rental_item_columns = rental_item_names.zip(value_columns).flatten  # 物品名と数量が連続する配列を作る
     csv = CSV.generate do |csv|

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -121,7 +121,7 @@ ActiveAdmin.register Group do
   collection_action :download_rental_item_list, :method => :get do
     groups = Group.where({ fes_year_id: FesYear.this_year})
     groups = groups.sort{|g1, g2| g1.group_category_id <=> g2.group_category_id}
-    rental_item_names = RentalItem.all.map{ |item| item.name_ja }
+    rental_item_names = RentalItem.where(is_rentable: true).map{ |item| item.name_ja }
     value_columns = rental_item_names.map{ |_| '数量' }  # 物品数と同じだけ数量カラムを作る
     rental_item_columns = rental_item_names.zip(value_columns).flatten  # 物品名と数量が連続する配列を作る
     csv = CSV.generate do |csv|

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -122,20 +122,33 @@ ActiveAdmin.register Group do
     groups = Group.where(fes_year_id: FesYear.this_year)
     groups = groups.sort{|g1, g2| g1.group_category_id <=> g2.group_category_id}  # category_id順にソート
     rental_item_allow_list_ids = RentalItemAllowList.pluck(:rental_item_id).uniq
-    # RentaiItemの内，is_rentable=trueかつRentalItemAllowListに存在する物品の名前を取得する
+    # RentaiItemのうち，is_rentable=trueかつRentalItemAllowListに存在する物品の名前を取得する
     rental_item_names = RentalItem.where(is_rentable: true).where(id: rental_item_allow_list_ids).pluck(:name_ja)
-    value_columns = rental_item_names.map{ |_| '数量' }  # 物品数と同じだけ数量カラムを作る
+    value_columns = rental_item_names.map{ |_| '数量' }  # 物品数と同じ数だけ'数量'を作る
     rental_item_columns = rental_item_names.zip(value_columns).flatten  # 物品名と数量が連続する配列を作る
+
     csv = CSV.generate do |csv|
-      csv << %w(No. 参加形式 団体名 エリア) + rental_item_columns
+      csv << %w(No. 参加形式 団体名 エリア) + rental_item_columns  # 1行目を出力
+
       groups.each_with_index do |group, i|
         group_name = group.name
         group_category_name = group.group_category.name_ja
-        if group.group_category_id == 3  # ステージ団体の場合
-          stage_order = StageOrder.where(group_id: group.id).first  # 1日目晴の申請
-          assign_stage = stage_order ? AssignStage.where(stage_order_id: stage_order.id).first : nil
-          assign_stage_name = assign_stage ? assign_stage.stage.name_ja + '(1日目晴)' : ''
+        # ステージ団体の場合
+        if group.group_category_id == 3
+          stage_order_first = StageOrder.where(group_id: group.id).first  # 1日目晴の申請
+          assign_stage_first = stage_order_first ? AssignStage.where(stage_order_id: stage_order_first.id).first : nil
+          if assign_stage_first and assign_stage_first.stage.id != 0
+            assign_stage_name = assign_stage_first.stage.name_ja + '(1日目晴)'
+          # 1日目晴の使用ステージが未入力なら2日目晴の使用ステージを見る
+          elsif assign_stage_first and assign_stage_first.stage.id == 0
+            stage_order_second = StageOrder.where(group_id: group.id).third  # 2日目晴の申請
+            assign_stage_second = stage_order_second ? AssignStage.where(stage_order_id: stage_order_second.id).first : nil
+            assign_stage_name = assign_stage_second.stage.name_ja + '(2日目晴)'
+          else
+            assign_stage_name = ''
+          end
           csv << [i+1, group_category_name, group_name, assign_stage_name]
+        # ステージ団体以外の場合
         else
           place_order = PlaceOrder.where(group_id: group.id).first
           assign_place = place_order ? AssignGroupPlace.where(place_order_id: place_order.id).first : nil


### PR DESCRIPTION
resolve: #357 

ダッシュボードに貸出物品表のテンプレートのcsvをダウンロードできる機能を追加
[20150911_物品貸し出し_佐藤追記.xlsx](https://github.com/NUTFes/group-manager/files/3285652/20150911_._.xlsx) この表の保管場所と数量を抜かしたcsvを出力する
