### PR TITLE
[バグ] 食販団体なのに購入リスト登録ができないバグの解消

### DIFF
--- a/app/helpers/purchase_lists_helper.rb
+++ b/app/helpers/purchase_lists_helper.rb
@@ -2,7 +2,8 @@ module PurchaseListsHelper
 
   def show_new_noncooking(fesdate)
     # 保存食品はいつでも買える
-    food_product = FoodProduct.find_by(group_id: @groups.first.id)
+    @group_ids = @groups.where(group_category_id: 1).pluck('id')
+    food_product = FoodProduct.find_by(group_id: @group_ids.first)
     # createが許可された場合のみNewボタンを表示する
     if @ability.can?(:create, PurchaseList.new(food_product_id: food_product.id))
       return link_to "#{fesdate.date}" + 'に購入する提供品を追加',
@@ -13,7 +14,8 @@ module PurchaseListsHelper
 
   def show_new_nonfresh(fesdate)
     # 保存食品はいつでも買える
-    food_product = FoodProduct.find_by(group_id: @groups.first.id)
+    @group_ids = @groups.where(group_category_id: 1).pluck('id')
+    food_product = FoodProduct.find_by(group_id: @group_ids.first)
     # createが許可された場合のみNewボタンを表示する
     if @ability.can?(:create, PurchaseList.new(food_product_id: food_product.id))
       return link_to "#{fesdate.date}" + 'に購入する保存食品を追加',
@@ -24,8 +26,8 @@ module PurchaseListsHelper
 
   def show_new_fresh(fesdate)
     return if fesdate.days_num == 0  # 準備日に生鮮食品は買えない
-
-    food_product = FoodProduct.find_by(group_id: @groups.first.id)
+    @group_ids = @groups.where(group_category_id: 1).pluck('id')
+    food_product = FoodProduct.find_by(group_id: @group_ids.first)
     # createが許可された場合のみNewボタンを表示する
     if @ability.can?(:create, PurchaseList.new(food_product_id: food_product.id))
       return link_to "#{fesdate.date}" + 'に使用する生鮮食品を追加',


### PR DESCRIPTION
複数の参加団体を登録していて，食販団体の登録が最初ではない場合，購入リスト登録画面が表示されない．StreetStyleの例だと，[ステージ団体, 食販団体]の順に参加団体が登録されていた．

原因は `app/helpers/purchase_lists_helper.rb` の

```
food_product = FoodProduct.find_by(group_id: @groups.first.id)
```

`@groups` にはそのユーザの全ての登録団体が入っているが，firstしか見ていないため，最初の登録団体が食販でなければerrorになる．
firstではなく食販団体のFoodProductが欲しいので，`@groups` の中の食販団体のidを取得してFoodProductを取得するようにした．