### PR TITLE
setup.mdにHerokuの情報を消して，VPSの情報を記載する

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -195,61 +195,29 @@ source ~/.***rc
 bundle exec rails s -e production
 ```
 
-# Heroku
+# VPS(サクラサーバー)
+## 現在の状況
+- ユーザ: root
+- directory: `/var/www/group-manager`
+- puma起動コマンド: `bin/rails s -e production`
+- pumaが起動しているかの確認: `ps aux|grep puma`
+- pumaの停止: `bundle exec pumactl -P tmp/pids/puma.pid halt`
+- pumaの再起動: `bundle exec pumactl -P tmp/pids/puma.pid restart`
+-nginxの設定ファイル: `/etc/nginx/sites-available/group-manager.nutfes.net`
+- 公開URL: https://group-manager.nutfes.net
 
-## Heroku設定
+## デプロイの仕方
+- VPSにrootユーザーでログイン
+  - `sudo su`
+- `cd /var/www/group-manager`
+- `git pull --rebase`
+- `bin/rake db:create RAILS_ENV=production` (最初のみ)
+- `bin/rake db:migrate RAILS_ENV=production` (必要に応じて)
+- `bin/rake db:seed_fu RAILS_ENV=production` (seedデータを書き換えた場合)
+- `bundle exec pumactl -P tmp/pids/puma.pid restart`
 
-別アプリ等で設定済みならば省略可
-
-```sh
-heroku login                      # herokuへログイン
-heroku keys:add ~/.ssh/id_rsa.pub # ssh公開鍵を登録
-```
-
-## アプリを登録
-
-```sh
-heroku apps:create 'アプリ名' --ssh-git
-```
-
-`<アプリ名>.herokuapp.com`で公開される
-
-## 環境変数の設定
-
-```sh
-# gmailの設定例
-heroku config:set SMTP_ADRESS=smtp.gmail.com
-heroku config:set SMTP_PORT=587
-heroku config:set EMAIL_DOMAIN=gmail.com
-heroku config:set SMTP_AUTH=plain
-heroku config:set SMTP_TLS=false
-heroku config:set EMAIL_USERNAME=<ユーザ名>@gmail.com
-heroku config:set EMAIL_BCC='<BCC送信先>@gmail.com'
-heroku config:set EMAIL_PASSWORD=<パスワード> # gmailの場合は2段階認証を設定後, アプリ固有のパスワードを設定する
-heroku config:set EMAIL_SENDER='送信者名 <ユーザ名@gmail.com>'
-heroku config:set DEFAULT_URL=https://<アプリ名>.herokuapp.com
-```
-
-## アプリ送信(初回)
-
-```sh
-git push heroku master     # push
-heroku run rake db:create  # DB作成
-heroku run rake db:migrate # DB構築
-heroku run rake db:seed_fu # 初期値投入
-```
-
-proxy環境下等で`heroku run`が使えない場合は`heroku run:detached`を使う.
-
-## アプリ送信(2回目以降)
-
-```sh
-git push heroku master     # push
-# 必要ならば
-heroku run rake db:migrate # DB構築
-heroku run rake db:seed_fu # 初期値投入
-```
-
+## アプリの配置場所
+今後も新しいアプリができて，それをデプロイするときは`/var/www/`の直下にアプリのディレクトリを保存する．
 
 ## 追記
 環境変数`EMAIL_PASSWORD`はGmail(nutfes.info)から生成されるアプリケーションごとに固有のパスワード(アプリパスワード)を設定する必要がある．  

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -203,7 +203,7 @@ bundle exec rails s -e production
 - pumaが起動しているかの確認: `ps aux|grep puma`
 - pumaの停止: `bundle exec pumactl -P tmp/pids/puma.pid halt`
 - pumaの再起動: `bundle exec pumactl -P tmp/pids/puma.pid restart`
--nginxの設定ファイル: `/etc/nginx/sites-available/group-manager.nutfes.net`
+- nginxの設定ファイル: `/etc/nginx/sites-available/group-manager.nutfes.net`
 - 公開URL: https://group-manager.nutfes.net
 
 ## デプロイの仕方


### PR DESCRIPTION
# 内容
Herokuが現在使われていないので，VPSでのデプロイの方法や，現在の状況等を`docs/setup.md`に記載した．

# 参考
https://github.com/NUTFes/group-manager/pull/334